### PR TITLE
feat: add PetIA MVP web app

### DIFF
--- a/PetIA/chat.html
+++ b/PetIA/chat.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PetIA - Chat</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/i18n.js"></script>
+  <script defer src="js/auth.js"></script>
+  <script defer src="js/app.js"></script>
+</head>
+<body class="bg-light">
+  <nav class="menu">
+    <a href="user.html" data-i18n="menu_profile">Perfil</a>
+    <a href="chat.html" data-i18n="menu_chat">Chat</a>
+    <a href="policy.html" data-i18n="menu_policy">Políticas</a>
+    <button id="logoutBtn" class="btn-secondary" data-i18n="logout">Salir</button>
+  </nav>
+  <main class="container">
+    <h1 data-i18n="chat_title">Chat</h1>
+    <iframe src="http://localhost:5678/webhook/e388905d-d5df-4b0e-9355-af241508fad2/chat" class="chat-frame"></iframe>
+  </main>
+</body>
+</html>

--- a/PetIA/config.json
+++ b/PetIA/config.json
@@ -1,0 +1,14 @@
+{
+  "apiBaseUrl": "https://example.com",
+  "endpoints": {
+    "login": "/wp-json/petia-app-bridge/v1/login",
+    "logout": "/wp-json/petia-app-bridge/v1/logout",
+    "validateToken": "/wp-json/petia-app-bridge/v1/validate-token",
+    "passwordResetRequest": "/wp-json/petia-app-bridge/v1/password-reset-request",
+    "passwordReset": "/wp-json/petia-app-bridge/v1/password-reset",
+    "profile": {
+      "get": "/wp-json/petia-app-bridge/v1/profile",
+      "update": "/wp-json/petia-app-bridge/v1/profile"
+    }
+  }
+}

--- a/PetIA/css/style.css
+++ b/PetIA/css/style.css
@@ -1,0 +1,62 @@
+:root {
+  --color-primary: #0A3A48;
+  --color-secondary: #5AC0AE;
+  --color-accent: #B7E6DD;
+  --color-text: #1B1B1B;
+  --color-bg: #F4F4F4;
+}
+
+body {
+  font-family: Arial, sans-serif;
+  color: var(--color-text);
+  background: var(--color-bg);
+  margin: 0;
+}
+
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.menu {
+  display: flex;
+  gap: 1rem;
+  background: var(--color-primary);
+  padding: 0.5rem 1rem;
+}
+
+.menu a, .menu button {
+  color: white;
+  text-decoration: none;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.btn-primary {
+  background: var(--color-secondary);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.btn-secondary {
+  background: var(--color-primary);
+  color: #fff;
+  border: none;
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+}
+
+.bg-light {
+  background: var(--color-bg);
+}
+
+.chat-frame {
+  width: 100%;
+  height: 500px;
+  border: 1px solid var(--color-accent);
+}

--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PetIA - Login</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/i18n.js"></script>
+  <script defer src="js/auth.js"></script>
+</head>
+<body class="bg-light">
+  <main class="container">
+    <h1 data-i18n="login_title">Iniciar sesión</h1>
+    <form id="loginForm">
+      <label for="username" data-i18n="username">Usuario</label>
+      <input type="text" id="username" required>
+      <label for="password" data-i18n="password">Contraseña</label>
+      <input type="password" id="password" required>
+      <button type="submit" class="btn-primary" data-i18n="login">Entrar</button>
+    </form>
+    <p><a href="recover.html" data-i18n="forgot_password">¿Olvidaste tu contraseña?</a></p>
+  </main>
+</body>
+</html>

--- a/PetIA/js/app.js
+++ b/PetIA/js/app.js
@@ -1,0 +1,34 @@
+async function loadConfig() {
+  if (!window.appConfig) {
+    window.appConfig = await fetch('config.json').then(r => r.json());
+  }
+  return window.appConfig;
+}
+
+async function getProfile() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    window.location.href = 'index.html';
+    return;
+  }
+  const config = await loadConfig();
+  const url = config.apiBaseUrl + config.endpoints.profile.get;
+  const res = await fetch(url, {
+    headers: { 'Authorization': `Bearer ${token}` }
+  });
+  if (res.ok) {
+    const data = await res.json();
+    const container = document.getElementById('userData');
+    if (container) {
+      container.innerHTML = `<p><strong>${data.name || ''}</strong></p><p>${data.email || ''}</p>`;
+    }
+  } else {
+    logout();
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.getElementById('userData')) {
+    getProfile();
+  }
+});

--- a/PetIA/js/auth.js
+++ b/PetIA/js/auth.js
@@ -1,0 +1,69 @@
+async function loadConfig() {
+  if (!window.appConfig) {
+    window.appConfig = await fetch('config.json').then(r => r.json());
+  }
+  return window.appConfig;
+}
+
+async function login(username, password) {
+  const config = await loadConfig();
+  const url = config.apiBaseUrl + config.endpoints.login;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) throw new Error('Login failed');
+  const data = await res.json();
+  localStorage.setItem('token', data.token);
+}
+
+async function requestPasswordReset(email) {
+  const config = await loadConfig();
+  const url = config.apiBaseUrl + config.endpoints.passwordResetRequest;
+  await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email })
+  });
+}
+
+function logout() {
+  localStorage.removeItem('token');
+  window.location.href = 'index.html';
+}
+
+// Event listeners
+const loginForm = document.getElementById('loginForm');
+if (loginForm) {
+  loginForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const username = document.getElementById('username').value;
+    const password = document.getElementById('password').value;
+    try {
+      await login(username, password);
+      window.location.href = 'user.html';
+    } catch (err) {
+      alert('Login error');
+    }
+  });
+}
+
+const recoverForm = document.getElementById('recoverForm');
+if (recoverForm) {
+  recoverForm.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const email = document.getElementById('email').value;
+    try {
+      await requestPasswordReset(email);
+      alert('Solicitud enviada');
+    } catch (err) {
+      alert('Error');
+    }
+  });
+}
+
+const logoutBtn = document.getElementById('logoutBtn');
+if (logoutBtn) {
+  logoutBtn.addEventListener('click', logout);
+}

--- a/PetIA/js/i18n.js
+++ b/PetIA/js/i18n.js
@@ -1,0 +1,11 @@
+(async function() {
+  const defaultLang = 'es';
+  const lang = (navigator.language || defaultLang).split('-')[0];
+  const translations = await fetch(`locales/${lang}.json`).then(r => r.ok ? r.json() : fetch(`locales/${defaultLang}.json`).then(r=>r.json()));
+  document.querySelectorAll('[data-i18n]').forEach(el => {
+    const key = el.getAttribute('data-i18n');
+    if (translations[key]) {
+      el.textContent = translations[key];
+    }
+  });
+})();

--- a/PetIA/locales/en.json
+++ b/PetIA/locales/en.json
@@ -1,0 +1,18 @@
+{
+  "login_title": "Login",
+  "username": "Username",
+  "password": "Password",
+  "login": "Login",
+  "forgot_password": "Forgot your password?",
+  "recover_title": "Password recovery",
+  "email": "Email",
+  "send": "Send",
+  "back_login": "Back to login",
+  "menu_profile": "Profile",
+  "menu_chat": "Chat",
+  "menu_policy": "Policies",
+  "logout": "Logout",
+  "user_info": "User information",
+  "chat_title": "Chat",
+  "policy_title": "Privacy policy"
+}

--- a/PetIA/locales/es.json
+++ b/PetIA/locales/es.json
@@ -1,0 +1,18 @@
+{
+  "login_title": "Iniciar sesión",
+  "username": "Usuario",
+  "password": "Contraseña",
+  "login": "Entrar",
+  "forgot_password": "¿Olvidaste tu contraseña?",
+  "recover_title": "Recuperar contraseña",
+  "email": "Correo electrónico",
+  "send": "Enviar",
+  "back_login": "Volver al login",
+  "menu_profile": "Perfil",
+  "menu_chat": "Chat",
+  "menu_policy": "Políticas",
+  "logout": "Salir",
+  "user_info": "Información del usuario",
+  "chat_title": "Chat",
+  "policy_title": "Políticas de privacidad"
+}

--- a/PetIA/policy.html
+++ b/PetIA/policy.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PetIA - Políticas</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/i18n.js"></script>
+  <script defer src="js/auth.js"></script>
+  <script defer src="js/app.js"></script>
+</head>
+<body class="bg-light">
+  <nav class="menu">
+    <a href="user.html" data-i18n="menu_profile">Perfil</a>
+    <a href="chat.html" data-i18n="menu_chat">Chat</a>
+    <a href="policy.html" data-i18n="menu_policy">Políticas</a>
+    <button id="logoutBtn" class="btn-secondary" data-i18n="logout">Salir</button>
+  </nav>
+  <main class="container">
+    <h1 data-i18n="policy_title">Políticas de privacidad</h1>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec odio. Praesent libero. Sed cursus ante dapibus diam.</p>
+  </main>
+</body>
+</html>

--- a/PetIA/recover.html
+++ b/PetIA/recover.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PetIA - Recuperar contraseña</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/i18n.js"></script>
+  <script defer src="js/auth.js"></script>
+</head>
+<body class="bg-light">
+  <main class="container">
+    <h1 data-i18n="recover_title">Recuperar contraseña</h1>
+    <form id="recoverForm">
+      <label for="email" data-i18n="email">Correo electrónico</label>
+      <input type="email" id="email" required>
+      <button type="submit" class="btn-primary" data-i18n="send">Enviar</button>
+    </form>
+    <p><a href="index.html" data-i18n="back_login">Volver al login</a></p>
+  </main>
+</body>
+</html>

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PetIA - Usuario</title>
+  <link rel="stylesheet" href="css/style.css">
+  <script defer src="js/i18n.js"></script>
+  <script defer src="js/auth.js"></script>
+  <script defer src="js/app.js"></script>
+</head>
+<body class="bg-light">
+  <nav class="menu">
+    <a href="user.html" data-i18n="menu_profile">Perfil</a>
+    <a href="chat.html" data-i18n="menu_chat">Chat</a>
+    <a href="policy.html" data-i18n="menu_policy">Políticas</a>
+    <button id="logoutBtn" class="btn-secondary" data-i18n="logout">Salir</button>
+  </nav>
+  <main class="container">
+    <h1 data-i18n="user_info">Información del usuario</h1>
+    <div id="userData"></div>
+  </main>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "petia-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "test": "echo 'No tests specified' && exit 0"
+  }
+}


### PR DESCRIPTION
## Summary
- create HTML-based PetIA app with login, user profile, chat and navigation
- add configurable endpoints and basic i18n support
- style with palette matching PetIA branding
- add package.json with placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e8f875838832397540b1c016c4950