### PR TITLE
Integrate bridge API endpoints and token validation

### DIFF
--- a/PetIA/config.js
+++ b/PetIA/config.js
@@ -7,9 +7,9 @@ export default {
     validateToken: "/wp-json/petia-app-bridge/v1/validate-token",
     passwordResetRequest: "/wp-json/petia-app-bridge/v1/password-reset-request",
     passwordReset: "/wp-json/petia-app-bridge/v1/password-reset",
-    profile: "/wp-json/petia-app-bridge/v1/profile"
-  },
-  woocommerce: {
-    products: "/wp-json/wc/v3/products"
+    profile: "/wp-json/petia-app-bridge/v1/profile",
+    productCategories: "/wp-json/petia-app-bridge/v1/product-categories",
+    products: "/wp-json/petia-app-bridge/v1/products",
+    brands: "/wp-json/petia-app-bridge/v1/brands"
   }
 };

--- a/PetIA/js/app.js
+++ b/PetIA/js/app.js
@@ -1,12 +1,10 @@
 import config from '../config.js';
-import { logout } from './auth.js';
+import { logout, validateToken } from './auth.js';
 
 async function getProfile() {
+  const valid = await validateToken();
+  if (!valid) return;
   const token = localStorage.getItem('token');
-  if (!token) {
-    window.location.href = 'index.html';
-    return;
-  }
   const url = config.apiBaseUrl + config.endpoints.profile;
   const res = await fetch(url, {
     headers: { 'Authorization': `Bearer ${token}` }
@@ -86,7 +84,9 @@ async function updateProfile(e) {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  const valid = await validateToken();
+  if (!valid) return;
   if (document.getElementById('userData')) {
     getProfile();
   }

--- a/PetIA/js/auth.js
+++ b/PetIA/js/auth.js
@@ -16,10 +16,6 @@ async function login(identifier, password) {
   }
   const data = await res.json();
   localStorage.setItem('token', data.token);
-  if (data.consumer_key && data.consumer_secret) {
-    localStorage.setItem('consumerKey', data.consumer_key);
-    localStorage.setItem('consumerSecret', data.consumer_secret);
-  }
 }
 
 async function requestPasswordReset(email) {
@@ -31,11 +27,43 @@ async function requestPasswordReset(email) {
   });
 }
 
-export function logout() {
+export async function logout() {
+  const token = localStorage.getItem('token');
+  if (token) {
+    const url = config.apiBaseUrl + config.endpoints.logout;
+    try {
+      await fetch(url, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` }
+      });
+    } catch (err) {
+      console.error('Logout error', err);
+    }
+  }
   localStorage.removeItem('token');
-  localStorage.removeItem('consumerKey');
-  localStorage.removeItem('consumerSecret');
   window.location.href = 'index.html';
+}
+
+export async function validateToken() {
+  const token = localStorage.getItem('token');
+  if (!token) {
+    await logout();
+    return false;
+  }
+  const url = config.apiBaseUrl + config.endpoints.validateToken;
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) {
+      await logout();
+      return false;
+    }
+    return true;
+  } catch (err) {
+    await logout();
+    return false;
+  }
 }
 
 // Event listeners

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -1,27 +1,25 @@
 import config from '../config.js';
-import { logout } from './auth.js';
+import { logout, validateToken } from './auth.js';
 
-function init() {
+async function init() {
   const logoutBtn = document.getElementById('logoutBtn');
   if (logoutBtn) {
     logoutBtn.addEventListener('click', logout);
   }
+  const valid = await validateToken();
+  if (!valid) return;
+  loadCategories();
+  loadBrands();
   loadProducts();
 }
 
-document.getElementById('logoutBtn').addEventListener('click', logout);
-
 async function loadProducts() {
-  const { products } = config.woocommerce;
-  const consumerKey = localStorage.getItem('consumerKey');
-  const consumerSecret = localStorage.getItem('consumerSecret');
-  if (!consumerKey || !consumerSecret) {
-    console.error('Missing WooCommerce credentials');
-    return;
-  }
-  const url = `${config.apiBaseUrl}${products}?consumer_key=${consumerKey}&consumer_secret=${consumerSecret}`;
+  const token = localStorage.getItem('token');
+  const url = config.apiBaseUrl + config.endpoints.products;
   try {
-    const res = await fetch(url);
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
     if (!res.ok) throw new Error('Failed to load products');
     const productsData = await res.json();
     renderProducts(productsData);
@@ -36,17 +34,76 @@ function renderProducts(products) {
   products.forEach(p => {
     const card = document.createElement('div');
     card.className = 'product-card';
-    const imgSrc = p.images && p.images[0] ? p.images[0].src : '';
+    const imgSrc = p.image || (p.images && p.images[0] ? p.images[0].src : '');
     card.innerHTML = `
       ${imgSrc ? `<img src="${imgSrc}" alt="${p.name}">` : ''}
       <h3>${p.name}</h3>
-      <p>${p.price_html || ''}</p>
+      <p>${p.price || p.price_html || ''}</p>
+    `;
+    container.appendChild(card);
+  });
+}
+
+async function loadCategories() {
+  const token = localStorage.getItem('token');
+  const url = config.apiBaseUrl + config.endpoints.productCategories;
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error('Failed to load categories');
+    const data = await res.json();
+    renderCategories(data);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function renderCategories(categories) {
+  const container = document.getElementById('categoryList');
+  if (!container) return;
+  container.innerHTML = '';
+  categories.forEach(c => {
+    const card = document.createElement('div');
+    card.className = 'product-card';
+    const imgSrc = c.image || (c.image && c.image.src ? c.image.src : '');
+    card.innerHTML = `
+      ${imgSrc ? `<img src="${imgSrc}" alt="${c.name}">` : ''}
+      <h3>${c.name}</h3>
+    `;
+    container.appendChild(card);
+  });
+}
+
+async function loadBrands() {
+  const token = localStorage.getItem('token');
+  const url = config.apiBaseUrl + config.endpoints.brands;
+  try {
+    const res = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` }
+    });
+    if (!res.ok) throw new Error('Failed to load brands');
+    const data = await res.json();
+    renderBrands(data);
+  } catch (err) {
+    console.error(err);
+  }
+}
+
+function renderBrands(brands) {
+  const container = document.getElementById('brandList');
+  if (!container) return;
+  container.innerHTML = '';
+  brands.forEach(b => {
+    const card = document.createElement('div');
+    card.className = 'product-card';
+    const imgSrc = b.image || (b.image && b.image.src ? b.image.src : '');
+    card.innerHTML = `
+      ${imgSrc ? `<img src="${imgSrc}" alt="${b.name}">` : ''}
+      <h3>${b.name}</h3>
     `;
     container.appendChild(card);
   });
 }
 
 document.addEventListener('DOMContentLoaded', init);
-
-loadProducts();
-

--- a/PetIA/locales/en.json
+++ b/PetIA/locales/en.json
@@ -16,5 +16,8 @@
   "user_info": "User information",
   "chat_title": "Chat",
   "store_title": "Store",
+  "categories_title": "Categories",
+  "brands_title": "Brands",
+  "products_title": "Products",
   "policy_title": "Privacy policy"
 }

--- a/PetIA/locales/es.json
+++ b/PetIA/locales/es.json
@@ -16,5 +16,8 @@
   "user_info": "Información del usuario",
   "chat_title": "Chat",
   "store_title": "Tienda",
+  "categories_title": "Categorías",
+  "brands_title": "Marcas",
+  "products_title": "Productos",
   "policy_title": "Políticas de privacidad"
 }

--- a/PetIA/store.html
+++ b/PetIA/store.html
@@ -19,6 +19,11 @@
   </nav>
   <main class="content">
     <h1 data-i18n="store_title">Tienda</h1>
+    <h2 data-i18n="categories_title">Categorías</h2>
+    <div id="categoryList" class="product-grid"></div>
+    <h2 data-i18n="brands_title">Marcas</h2>
+    <div id="brandList" class="product-grid"></div>
+    <h2 data-i18n="products_title">Productos</h2>
     <div id="productList" class="product-grid"></div>
   </main>
 </body>


### PR DESCRIPTION
## Summary
- Invoke bridge logout endpoint to revoke tokens and added validation helper.
- Switch product, category, and brand requests to bridge API and drop WooCommerce keys.
- Add localized headings and UI sections for categories, brands, and products.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfa23bc7988323ab5f8e170e495c1e