### PR TITLE
feat: use email only for login

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -230,23 +230,19 @@ class PetIA_App_Bridge {
      * Handle user login and token generation.
      */
     public function handle_login( WP_REST_Request $request ) {
-        $username = sanitize_user( $request->get_param( 'username' ) );
         $email    = sanitize_email( $request->get_param( 'email' ) );
         $password = $request->get_param( 'password' );
 
-        if ( empty( $password ) || ( empty( $username ) && empty( $email ) ) ) {
-            return new WP_Error( 'missing_fields', __( 'Email or username and password are required.', 'petia-app-bridge' ), [ 'status' => 400 ] );
+        if ( empty( $email ) || empty( $password ) ) {
+            return new WP_Error( 'missing_fields', __( 'Email and password are required.', 'petia-app-bridge' ), [ 'status' => 400 ] );
         }
 
-        if ( ! empty( $email ) ) {
-            $user_obj = get_user_by( 'email', $email );
-            if ( ! $user_obj ) {
-                return new WP_Error( 'invalid_credentials', __( 'Invalid email or password.', 'petia-app-bridge' ), [ 'status' => 401 ] );
-            }
-            $username = $user_obj->user_login;
+        $user_obj = get_user_by( 'email', $email );
+        if ( ! $user_obj ) {
+            return new WP_Error( 'invalid_credentials', __( 'Invalid email or password.', 'petia-app-bridge' ), [ 'status' => 401 ] );
         }
 
-        $user = wp_authenticate( $username, $password );
+        $user = wp_authenticate( $user_obj->user_login, $password );
         if ( is_wp_error( $user ) ) {
             return $user;
         }

--- a/PetIA-app-bridge/README.md
+++ b/PetIA-app-bridge/README.md
@@ -11,7 +11,7 @@ Este plugin de WordPress expone un conjunto de endpoints REST para que una aplic
 
 - `POST /wp-json/petia-app-bridge/v1/login`
   - Autentica al usuario y devuelve un token.
-  - Parámetros: `email` o `username`, `password`.
+  - Parámetros: `email`, `password`.
 
 - `POST /wp-json/petia-app-bridge/v1/logout`
   - Revoca el token actual enviado en el encabezado `Authorization: Bearer <token>`.

--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -13,8 +13,8 @@
   <main class="content">
     <h1 data-i18n="login_title">Iniciar sesión</h1>
     <form id="loginForm">
-      <label for="username" data-i18n="username">Usuario</label>
-      <input type="text" id="username" required>
+      <label for="email" data-i18n="email">Correo electrónico</label>
+      <input type="email" id="email" required>
       <label for="password" data-i18n="password">Contraseña</label>
       <input type="password" id="password" required>
       <button type="submit" class="btn-primary" data-i18n="login">Entrar</button>

--- a/PetIA/js/auth.js
+++ b/PetIA/js/auth.js
@@ -1,10 +1,8 @@
 import config from '../config.js';
 
-async function login(identifier, password) {
+async function login(email, password) {
   const url = config.apiBaseUrl + config.endpoints.login;
-  const payload = identifier.includes('@')
-    ? { email: identifier, password }
-    : { username: identifier, password };
+  const payload = { email, password };
   const res = await fetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -72,10 +70,10 @@ if (loginForm) {
   loginForm.addEventListener('submit', async (e) => {
     e.preventDefault();
 
-    const identifier = document.getElementById('username').value;
+    const email = document.getElementById('email').value;
     const password = document.getElementById('password').value;
     try {
-      await login(identifier, password);
+      await login(email, password);
       window.location.href = 'user.html';
     } catch (err) {
       alert('Login error');


### PR DESCRIPTION
## Summary
- restrict login to email credentials only on frontend and backend
- update index.html login form and docs to reflect email-only login

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb4709b988323b3f46e498fee5e45