### PR TITLE
feat: handle missing origin header

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -134,9 +134,10 @@ class PetIA_App_Bridge {
                 $origin = trim( $_SERVER['HTTP_X_FORWARDED_ORIGIN'] );
             }
 
-            $origin_valid = $origin && 'null' !== $origin;
+            $origin_provided = '' !== $origin;
+            $origin_valid    = ! $origin_provided || 'null' !== $origin;
 
-            if ( $origin_valid ) {
+            if ( $origin_provided && $origin_valid ) {
                 header( "Access-Control-Allow-Origin: {$origin}" );
                 header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
                 header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
@@ -148,7 +149,7 @@ class PetIA_App_Bridge {
                 return true;
             }
 
-            if ( ! $origin_valid ) {
+            if ( $origin_provided && ! $origin_valid ) {
                 status_header( 400 );
             }
 
@@ -172,16 +173,19 @@ class PetIA_App_Bridge {
                 $origin = trim( $_SERVER['HTTP_X_FORWARDED_ORIGIN'] );
             }
 
-            $origin_valid = $origin && 'null' !== $origin;
+            $origin_provided = '' !== $origin;
+            $origin_valid    = ! $origin_provided || 'null' !== $origin;
 
-            if ( $origin_valid ) {
+            if ( $origin_provided && $origin_valid ) {
                 header( "Access-Control-Allow-Origin: {$origin}" );
                 header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
                 header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
                 header( 'Access-Control-Allow-Credentials: true' );
                 status_header( 200 );
-            } else {
+            } elseif ( $origin_provided && ! $origin_valid ) {
                 status_header( 400 );
+            } else {
+                status_header( 200 );
             }
 
             exit;


### PR DESCRIPTION
## Summary
- avoid 400 status when request lacks Origin header
- keep sending CORS headers for OPTIONS requests
- align preflight handler with updated Origin checks

## Testing
- `php -l PetIA-app-bridge/PetIA-app-bridge.php`
- `curl -i http://localhost/wp-json/petia-app-bridge/v1/login -X POST -d 'email=test@example.com&password=pass'` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcea7447c8323ad9d4914ff74794a