### PR TITLE
feat: unify API calls with auth helper

### DIFF
--- a/PetIA/js/apiFetch.js
+++ b/PetIA/js/apiFetch.js
@@ -1,0 +1,30 @@
+import { logout } from './auth.js';
+
+export async function apiFetch(url, options = {}) {
+  const { skipAuthError, ...fetchOptions } = options;
+  const token = localStorage.getItem('token');
+  const headers = { ...(fetchOptions.headers || {}) };
+
+  if (token) {
+    headers.Authorization = `Bearer ${token}`;
+    try {
+      const [, payload] = token.split('.');
+      if (payload) {
+        const { exp } = JSON.parse(atob(payload));
+        if (exp && Date.now() >= exp * 1000) {
+          await logout();
+          throw new Error('Token expired');
+        }
+      }
+    } catch (err) {
+      console.error('Token parse error', err);
+    }
+  }
+
+  const res = await fetch(url, { ...fetchOptions, headers });
+  if (res.status === 401 && token && !skipAuthError) {
+    await logout();
+    throw new Error('Unauthorized');
+  }
+  return res;
+}

--- a/PetIA/js/app.js
+++ b/PetIA/js/app.js
@@ -1,14 +1,12 @@
 import config from '../config.js';
 import { logout, validateToken } from './auth.js';
+import { apiFetch } from './apiFetch.js';
 
 async function getProfile() {
   const valid = await validateToken();
   if (!valid) return;
-  const token = localStorage.getItem('token');
   const url = config.apiBaseUrl + config.endpoints.profile;
-  const res = await fetch(url, {
-    headers: { 'Authorization': `Bearer ${token}` }
-  });
+  const res = await apiFetch(url);
   if (res.ok) {
     const data = await res.json();
     renderProfileForm(data);
@@ -55,24 +53,15 @@ function renderProfileForm(data) {
 
 async function updateProfile(e) {
   e.preventDefault();
-  const token = localStorage.getItem('token');
-  if (!token) {
-    window.location.href = 'index.html';
-    return;
-  }
-
   const form = e.target;
   const data = Object.fromEntries(new FormData(form).entries());
   delete data.username;
   delete data.email;
 
   const url = config.apiBaseUrl + config.endpoints.profile;
-  const res = await fetch(url, {
+  const res = await apiFetch(url, {
     method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${token}`
-    },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(data)
   });
 

--- a/PetIA/js/auth.js
+++ b/PetIA/js/auth.js
@@ -1,9 +1,10 @@
 import config from '../config.js';
+import { apiFetch } from './apiFetch.js';
 
 async function login(email, password) {
   const url = config.apiBaseUrl + config.endpoints.login;
   const payload = { email, password };
-  const res = await fetch(url, {
+  const res = await apiFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload)
@@ -18,10 +19,11 @@ async function login(email, password) {
 
 async function requestPasswordReset(email) {
   const url = config.apiBaseUrl + config.endpoints.passwordResetRequest;
-  await fetch(url, {
+  await apiFetch(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email })
+    body: JSON.stringify({ email }),
+    skipAuthError: true
   });
 }
 
@@ -30,10 +32,7 @@ export async function logout() {
   if (token) {
     const url = config.apiBaseUrl + config.endpoints.logout;
     try {
-      await fetch(url, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` }
-      });
+      await apiFetch(url, { method: 'POST', skipAuthError: true });
     } catch (err) {
       console.error('Logout error', err);
     }
@@ -50,9 +49,7 @@ export async function validateToken() {
   }
   const url = config.apiBaseUrl + config.endpoints.validateToken;
   try {
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await apiFetch(url, { skipAuthError: true });
     if (!res.ok) {
       await logout();
       return false;

--- a/PetIA/js/i18n.js
+++ b/PetIA/js/i18n.js
@@ -1,7 +1,13 @@
+import { apiFetch } from './apiFetch.js';
+
 (async function() {
   const defaultLang = 'es';
   const lang = (navigator.language || defaultLang).split('-')[0];
-  const translations = await fetch(`locales/${lang}.json`).then(r => r.ok ? r.json() : fetch(`locales/${defaultLang}.json`).then(r=>r.json()));
+  let res = await apiFetch(`locales/${lang}.json`, { skipAuthError: true });
+  if (!res.ok) {
+    res = await apiFetch(`locales/${defaultLang}.json`, { skipAuthError: true });
+  }
+  const translations = await res.json();
   document.querySelectorAll('[data-i18n]').forEach(el => {
     const key = el.getAttribute('data-i18n');
     if (translations[key]) {

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -1,5 +1,6 @@
 import config from '../config.js';
 import { logout, validateToken } from './auth.js';
+import { apiFetch } from './apiFetch.js';
 
 async function init() {
   const logoutBtn = document.getElementById('logoutBtn');
@@ -14,12 +15,9 @@ async function init() {
 }
 
 async function loadProducts() {
-  const token = localStorage.getItem('token');
   const url = config.apiBaseUrl + config.endpoints.products;
   try {
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await apiFetch(url);
     if (!res.ok) throw new Error('Failed to load products');
     const productsData = await res.json();
     renderProducts(productsData);
@@ -45,12 +43,9 @@ function renderProducts(products) {
 }
 
 async function loadCategories() {
-  const token = localStorage.getItem('token');
   const url = config.apiBaseUrl + config.endpoints.productCategories;
   try {
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await apiFetch(url);
     if (!res.ok) throw new Error('Failed to load categories');
     const data = await res.json();
     renderCategories(data);
@@ -76,12 +71,9 @@ function renderCategories(categories) {
 }
 
 async function loadBrands() {
-  const token = localStorage.getItem('token');
   const url = config.apiBaseUrl + config.endpoints.brands;
   try {
-    const res = await fetch(url, {
-      headers: { Authorization: `Bearer ${token}` }
-    });
+    const res = await apiFetch(url);
     if (!res.ok) throw new Error('Failed to load brands');
     const data = await res.json();
     renderBrands(data);


### PR DESCRIPTION
## Summary
- add apiFetch helper to append auth token and handle expiration
- refactor modules to use apiFetch for API calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfcf5e4b488323b34ecce91bc5940a