### PR TITLE
refactor: remove unused authHeaders helper

### DIFF
--- a/PetIA/js/token.js
+++ b/PetIA/js/token.js
@@ -10,12 +10,11 @@ export function clearToken() {
   localStorage.removeItem('token');
 }
 
-export function authHeaders(headers = {}) {
-  const token = getToken();
-  return token ? { ...headers, Authorization: `Bearer ${token}` } : { ...headers };
-}
-
 export async function fetchWithAuth(url, options = {}) {
-  const headers = authHeaders(options.headers || {});
+  const token = getToken();
+  const baseHeaders = options.headers || {};
+  const headers = token
+    ? { ...baseHeaders, Authorization: `Bearer ${token}` }
+    : baseHeaders;
   return fetch(url, { ...options, headers });
 }


### PR DESCRIPTION
## Summary
- simplify token utilities by inlining auth header creation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd1ba44a08323ac52b080b9c94030