### PR TITLE
Guard API base URL when process is undefined

### DIFF
--- a/PetIA/config.js
+++ b/PetIA/config.js
@@ -1,6 +1,8 @@
 // Application configuration
 const apiBaseUrl =
-  process.env.API_BASE_URL ||
+  (typeof process !== "undefined" &&
+    process.env &&
+    process.env.API_BASE_URL) ||
   globalThis.API_BASE_URL ||
   "https://laboticaanimal.com";
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
-    "start": "cross-env NODE_OPTIONS=--experimental-vm-modules jest"
+    "start": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
+    "build": "echo 'No build step defined'"
   },
   "devDependencies": {
     "jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- Avoid reading `process.env` unless `process` exists to prevent browser runtime errors
- Add a placeholder `build` script so `npm run build` succeeds

## Testing
- `npm test`
- `npm run build`
- `node -e "const p=globalThis.process; globalThis.process=undefined; import('./PetIA/config.js').then(m=>console.log(m.default.apiBaseUrl)).finally(()=>{globalThis.process=p;});"`


------
https://chatgpt.com/codex/tasks/task_e_68bff99ee6f08323bf0b92d16ffc9314