### PR TITLE
Allow all origins by default

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -11,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+if ( ! defined( 'PETIA_ALLOWED_ORIGINS' ) ) {
+    define( 'PETIA_ALLOWED_ORIGINS', '*' );
+}
+
 if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require __DIR__ . '/vendor/autoload.php';
 }

--- a/PetIA-app-bridge/README.md
+++ b/PetIA-app-bridge/README.md
@@ -8,18 +8,18 @@ Plugin de WordPress que expone endpoints REST para que aplicaciones externas use
 - Catálogo de categorías, productos y marcas.
 - Control de acceso por usuario con fechas de vigencia.
 - Menú de administración **PetIA Bridge** con pestañas de acceso y ejecución de pruebas.
-- Soporte CORS configurable mediante la constante `PETIA_ALLOWED_ORIGINS`.
+- Soporte CORS configurable mediante la constante `PETIA_ALLOWED_ORIGINS` (por defecto permite todos los dominios).
 
 ## Requisitos
 - WordPress 5.0 o superior.
 - WooCommerce.
-- Definir `AUTH_KEY` y `PETIA_ALLOWED_ORIGINS` en `wp-config.php`.
+- Definir `AUTH_KEY` y, opcionalmente, `PETIA_ALLOWED_ORIGINS` en `wp-config.php` para restringir dominios.
 - Node.js si se desean correr pruebas desde el administrador.
 
 ## Instalación
 1. Copia `PetIA-app-bridge` a `wp-content/plugins/`.
 2. Activa el plugin en el panel de WordPress.
-3. Configura `PETIA_ALLOWED_ORIGINS` con una lista separada por comas de dominios permitidos.
+3. (Opcional) Configura `PETIA_ALLOWED_ORIGINS` con una lista separada por comas de dominios permitidos (por defecto `*`).
 4. Gestiona las fechas de acceso desde **PetIA Bridge** en la pestaña *Access Control*.
 5. (Opcional) Ejecuta las pruebas desde la pestaña *Run Tests* del mismo menú.
 

--- a/PetIA-app-bridge/includes/class-petia-cors.php
+++ b/PetIA-app-bridge/includes/class-petia-cors.php
@@ -38,11 +38,17 @@ class PetIA_CORS {
     }
 
     public function is_origin_allowed( $origin ) {
-        $allowed = defined( 'PETIA_ALLOWED_ORIGINS' ) ? array_map( 'trim', explode( ',', PETIA_ALLOWED_ORIGINS ) ) : [ get_site_url() ];
+        if ( ! defined( 'PETIA_ALLOWED_ORIGINS' ) || '*' === PETIA_ALLOWED_ORIGINS ) {
+            return true;
+        }
+        $allowed = array_map( 'trim', explode( ',', PETIA_ALLOWED_ORIGINS ) );
         return in_array( $origin, $allowed, true );
     }
 
     protected function send_cors_headers( $origin ) {
+        if ( defined( 'PETIA_ALLOWED_ORIGINS' ) && '*' === PETIA_ALLOWED_ORIGINS ) {
+            $origin = '*';
+        }
         header( "Access-Control-Allow-Origin: {$origin}" );
         header( 'Access-Control-Allow-Methods: GET, POST, OPTIONS' );
         header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );

--- a/PetIA-app-bridge/tests/CorsTest.php
+++ b/PetIA-app-bridge/tests/CorsTest.php
@@ -1,18 +1,29 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if ( ! defined('PETIA_ALLOWED_ORIGINS') ) {
-    define('PETIA_ALLOWED_ORIGINS', 'https://allowed.com,https://other.com');
-}
 if ( ! function_exists('get_site_url') ) {
     function get_site_url(){ return 'https://default.com'; }
 }
 
+if ( ! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
 require_once __DIR__ . '/../vendor/autoload.php';
-require_once __DIR__ . '/../includes/class-petia-cors.php';
 
 class CorsTest extends TestCase {
-    public function testOriginAllowed() {
+    public function testAllowsAllOriginsByDefault() {
+        require __DIR__ . '/../includes/class-petia-cors.php';
+        $cors = new PetIA_CORS();
+        $this->assertTrue($cors->is_origin_allowed('https://any.com'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testOriginAllowedWithConfiguredList() {
+        define('PETIA_ALLOWED_ORIGINS', 'https://allowed.com,https://other.com');
+        require __DIR__ . '/../includes/class-petia-cors.php';
         $cors = new PetIA_CORS();
         $this->assertTrue($cors->is_origin_allowed('https://allowed.com'));
         $this->assertFalse($cors->is_origin_allowed('https://evil.com'));

--- a/PetIA-app-bridge/tests/TokenTest.php
+++ b/PetIA-app-bridge/tests/TokenTest.php
@@ -20,6 +20,10 @@ if ( ! function_exists('wp_die') ) { function wp_die($msg){ throw new Exception(
 if ( ! function_exists('get_transient') ) { function get_transient(){ return false; } }
 if ( ! function_exists('set_transient') ) { function set_transient(){ return true; } }
 
+if ( ! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../includes/class-petia-token-manager.php';
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Repositorio que combina la aplicación web **PetIA** y el plugin de WordPress **
 - Una instalación de WordPress (con WooCommerce) para usar el plugin.
 
 ## Configuración rápida
-1. **Plugin**: copia `PetIA-app-bridge` en `wp-content/plugins/`, actívalo y define `AUTH_KEY` y `PETIA_ALLOWED_ORIGINS` en `wp-config.php`. Consulta el [README del plugin](PetIA-app-bridge/README.md).
+1. **Plugin**: copia `PetIA-app-bridge` en `wp-content/plugins/`, actívalo y define `AUTH_KEY`. Si deseas restringir dominios, configura `PETIA_ALLOWED_ORIGINS` en `wp-config.php`. Consulta el [README del plugin](PetIA-app-bridge/README.md).
 2. **Aplicación**: sirve el contenido de `PetIA/` en un servidor estático y ajusta `apiBaseUrl` en `PetIA/config.js`. Más detalles en el [README de la app](PetIA/README.md).
 
 ## Pruebas


### PR DESCRIPTION
## Summary
- Default `PETIA_ALLOWED_ORIGINS` to `*` and handle wildcard in CORS headers
- Update docs to note optional `PETIA_ALLOWED_ORIGINS` and wildcard default
- Add tests for wildcard CORS and define `ABSPATH` for unit tests

## Testing
- `npm test`
- `cd PetIA-app-bridge && ./vendor/bin/phpunit`


------
https://chatgpt.com/codex/tasks/task_e_68bffcf664d883239ed34804a6ceadd9