### PR TITLE
Handle wildcard CORS origins

### DIFF
--- a/PetIA-app-bridge/tests/CorsTest.php
+++ b/PetIA-app-bridge/tests/CorsTest.php
@@ -1,8 +1,8 @@
 <?php
 use PHPUnit\Framework\TestCase;
 
-if ( ! defined('PETIA_ALLOWED_ORIGINS') ) {
-    define('PETIA_ALLOWED_ORIGINS', 'https://allowed.com,https://other.com');
+if ( ! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__ . '/');
 }
 if ( ! function_exists('get_site_url') ) {
     function get_site_url(){ return 'https://default.com'; }
@@ -12,9 +12,55 @@ require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/../includes/class-petia-cors.php';
 
 class CorsTest extends TestCase {
+    /**
+     * @runInSeparateProcess
+     */
     public function testOriginAllowed() {
+        define('PETIA_ALLOWED_ORIGINS', 'https://allowed.com,https://other.com');
         $cors = new PetIA_CORS();
         $this->assertTrue($cors->is_origin_allowed('https://allowed.com'));
         $this->assertFalse($cors->is_origin_allowed('https://evil.com'));
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testWildcardAllowsAllOrigins() {
+        define('PETIA_ALLOWED_ORIGINS', '*');
+        $headers = [];
+        $cors    = new PetIA_CORS(function($h) use (&$headers){ $headers[] = $h; });
+        $origin  = 'https://example.com';
+
+        $this->assertTrue($cors->is_origin_allowed($origin));
+
+        $prop = new ReflectionProperty(PetIA_CORS::class, 'allow_all');
+        $prop->setAccessible(true);
+        $this->assertTrue($prop->getValue($cors));
+
+        $method = new ReflectionMethod(PetIA_CORS::class, 'send_cors_headers');
+        $method->setAccessible(true);
+        $method->invoke($cors, $origin);
+
+        $this->assertContains("Access-Control-Allow-Origin: {$origin}", $headers);
+        $this->assertContains('Vary: Origin', $headers);
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testSpecificOriginsDoNotVary() {
+        define('PETIA_ALLOWED_ORIGINS', 'https://allowed.com');
+        $headers = [];
+        $cors    = new PetIA_CORS(function($h) use (&$headers){ $headers[] = $h; });
+        $origin  = 'https://allowed.com';
+
+        $this->assertTrue($cors->is_origin_allowed($origin));
+
+        $method = new ReflectionMethod(PetIA_CORS::class, 'send_cors_headers');
+        $method->setAccessible(true);
+        $method->invoke($cors, $origin);
+
+        $this->assertContains("Access-Control-Allow-Origin: {$origin}", $headers);
+        $this->assertNotContains('Vary: Origin', $headers);
     }
 }

--- a/PetIA-app-bridge/tests/TokenTest.php
+++ b/PetIA-app-bridge/tests/TokenTest.php
@@ -7,6 +7,9 @@ if ( ! defined('AUTH_KEY') ) {
 if ( ! defined('DAY_IN_SECONDS') ) {
     define('DAY_IN_SECONDS', 86400);
 }
+if ( ! defined('ABSPATH') ) {
+    define('ABSPATH', __DIR__ . '/');
+}
 
 // Minimal WordPress stubs
 if ( ! function_exists('add_action') ) { function add_action(...$args) {} }


### PR DESCRIPTION
## Summary
- allow `*` in `PETIA_ALLOWED_ORIGINS` to accept any origin and vary on request origin
- cover wildcard origin behaviour with new unit tests
- inject header emitter into CORS class to validate headers in tests

## Testing
- `php ./vendor/bin/phpunit`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0011f0ea88323bbafb0c1b6121b15