### PR TITLE
Improve plugin activation checks and token manager

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -21,5 +21,51 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
 
 require_once __DIR__ . '/includes/class-petia-app-bridge.php';
 
-register_activation_hook( __FILE__, [ 'PetIA_App_Bridge', 'activate' ] );
-new PetIA_App_Bridge();
+register_activation_hook( __FILE__, function() {
+    if ( ! file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+        add_action( 'admin_notices', function() {
+            echo '<div class="error"><p>' . esc_html__( 'PetIA App Bridge requires composer dependencies. Please run composer install.', 'petia-app-bridge' ) . '</p></div>';
+        } );
+        return;
+    }
+
+    require_once __DIR__ . '/vendor/autoload.php';
+
+    if ( ! class_exists( 'Firebase\\JWT\\JWT' ) ) {
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+        add_action( 'admin_notices', function() {
+            echo '<div class="error"><p>' . esc_html__( 'PetIA App Bridge requires the Firebase JWT library. Please run composer install.', 'petia-app-bridge' ) . '</p></div>';
+        } );
+        return;
+    }
+
+    if ( ! defined( 'AUTH_KEY' ) || empty( AUTH_KEY ) || 'change_this_secret_key' === AUTH_KEY ) {
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+        add_action( 'admin_notices', function() {
+            echo '<div class="error"><p>' . esc_html__( 'AUTH_KEY must be defined in wp-config.php.', 'petia-app-bridge' ) . '</p></div>';
+        } );
+        return;
+    }
+
+    PetIA_App_Bridge::activate();
+} );
+
+add_action( 'plugins_loaded', function() {
+    if ( ! class_exists( 'WooCommerce' ) ) {
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+        add_action( 'admin_notices', function() {
+            echo '<div class="error"><p>' . esc_html__( 'PetIA App Bridge requires WooCommerce to be active.', 'petia-app-bridge' ) . '</p></div>';
+        } );
+        return;
+    }
+
+    try {
+        new PetIA_App_Bridge();
+    } catch ( Exception $e ) {
+        deactivate_plugins( plugin_basename( __FILE__ ) );
+        add_action( 'admin_notices', function() use ( $e ) {
+            echo '<div class="error"><p>' . esc_html( $e->getMessage() ) . '</p></div>';
+        } );
+    }
+} );

--- a/PetIA-app-bridge/includes/class-petia-token-manager.php
+++ b/PetIA-app-bridge/includes/class-petia-token-manager.php
@@ -11,7 +11,7 @@ class PetIA_Token_Manager {
 
     public function __construct() {
         if ( ! defined( 'AUTH_KEY' ) || empty( AUTH_KEY ) || 'change_this_secret_key' === AUTH_KEY ) {
-            wp_die( __( 'AUTH_KEY must be defined in wp-config.php.', 'petia-app-bridge' ) );
+            throw new \Exception( __( 'AUTH_KEY must be defined in wp-config.php.', 'petia-app-bridge' ) );
         }
         $this->secret = AUTH_KEY;
     }


### PR DESCRIPTION
## Summary
- Guard plugin activation when composer dependencies or AUTH_KEY are missing
- Throw exceptions instead of wp_die for missing AUTH_KEY and handle them gracefully
- Delay plugin boot until `plugins_loaded` and verify WooCommerce is active

## Testing
- `composer test`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c085f8c6288323b88f8f618cbf9005