### PR TITLE
Prevent PetIA bridge from deactivating itself

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -12,27 +12,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Ensure that Composer dependencies are installed.
- *
- * Attempts to run `composer install` when the vendor autoloader is missing.
+ * Check if Composer dependencies are available.
  *
  * @return bool True when dependencies are available, false otherwise.
  */
 function petia_app_bridge_ensure_dependencies() {
     $autoload = __DIR__ . '/vendor/autoload.php';
-
-    if ( file_exists( $autoload ) ) {
-        return true;
-    }
-
-    $cmd         = 'cd ' . escapeshellarg( __DIR__ ) . ' && composer install --no-dev --prefer-dist 2>&1';
-    $output      = array();
-    $return_code = 0;
-    exec( $cmd, $output, $return_code );
-
-    if ( 0 !== $return_code ) {
-        error_log( 'Composer install failed: ' . implode( "\n", $output ) );
-    }
 
     return file_exists( $autoload );
 }
@@ -41,19 +26,19 @@ if ( ! petia_app_bridge_ensure_dependencies() ) {
     add_action(
         'admin_notices',
         function () {
-            echo '<div class="notice notice-error"><p>' . esc_html__( 'PetIA App Bridge could not install Composer dependencies. Please run composer install.', 'petia-app-bridge' ) . '</p></div>';
+            printf( '<div class="notice notice-error"><p>%s</p></div>', esc_html__( 'PetIA App Bridge could not install Composer dependencies. Please run composer install.', 'petia-app-bridge' ) );
         }
     );
     return;
 }
 
-require __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 
 if ( ! class_exists( '\\Firebase\\JWT\\JWT' ) ) {
     add_action(
         'admin_notices',
         function () {
-            echo '<div class="notice notice-error"><p>' . esc_html__( 'PetIA App Bridge requires the firebase/php-jwt library. Please run composer install.', 'petia-app-bridge' ) . '</p></div>';
+            printf( '<div class="notice notice-error"><p>%s</p></div>', esc_html__( 'PetIA App Bridge requires the firebase/php-jwt library. Please run composer install.', 'petia-app-bridge' ) );
         }
     );
     return;
@@ -65,7 +50,7 @@ register_activation_hook( __FILE__, function() {
     if ( ! petia_app_bridge_ensure_dependencies() ) {
         deactivate_plugins( plugin_basename( __FILE__ ) );
         add_action( 'admin_notices', function() {
-            echo '<div class="error"><p>' . esc_html__( 'PetIA App Bridge requires composer dependencies. Composer install failed.', 'petia-app-bridge' ) . '</p></div>';
+            printf( '<div class="error"><p>%s</p></div>', esc_html__( 'PetIA App Bridge requires composer dependencies. Composer install failed.', 'petia-app-bridge' ) );
         } );
         return;
     }
@@ -75,7 +60,7 @@ register_activation_hook( __FILE__, function() {
     if ( ! class_exists( 'Firebase\\JWT\\JWT' ) ) {
         deactivate_plugins( plugin_basename( __FILE__ ) );
         add_action( 'admin_notices', function() {
-            echo '<div class="error"><p>' . esc_html__( 'PetIA App Bridge requires the Firebase JWT library. Please run composer install.', 'petia-app-bridge' ) . '</p></div>';
+            printf( '<div class="error"><p>%s</p></div>', esc_html__( 'PetIA App Bridge requires the Firebase JWT library. Please run composer install.', 'petia-app-bridge' ) );
         } );
         return;
     }
@@ -83,7 +68,7 @@ register_activation_hook( __FILE__, function() {
     if ( ! defined( 'AUTH_KEY' ) || empty( AUTH_KEY ) || 'change_this_secret_key' === AUTH_KEY ) {
         deactivate_plugins( plugin_basename( __FILE__ ) );
         add_action( 'admin_notices', function() {
-            echo '<div class="error"><p>' . esc_html__( 'AUTH_KEY must be defined in wp-config.php.', 'petia-app-bridge' ) . '</p></div>';
+            printf( '<div class="error"><p>%s</p></div>', esc_html__( 'AUTH_KEY must be defined in wp-config.php.', 'petia-app-bridge' ) );
         } );
         return;
     }
@@ -95,7 +80,7 @@ add_action( 'plugins_loaded', function() {
     if ( ! class_exists( 'WooCommerce' ) ) {
         deactivate_plugins( plugin_basename( __FILE__ ) );
         add_action( 'admin_notices', function() {
-            echo '<div class="error"><p>' . esc_html__( 'PetIA App Bridge requires WooCommerce to be active.', 'petia-app-bridge' ) . '</p></div>';
+            printf( '<div class="error"><p>%s</p></div>', esc_html__( 'PetIA App Bridge requires WooCommerce to be active.', 'petia-app-bridge' ) );
         } );
         return;
     }
@@ -105,7 +90,7 @@ add_action( 'plugins_loaded', function() {
     } catch ( Exception $e ) {
         deactivate_plugins( plugin_basename( __FILE__ ) );
         add_action( 'admin_notices', function() use ( $e ) {
-            echo '<div class="error"><p>' . esc_html( $e->getMessage() ) . '</p></div>';
+            printf( '<div class="error"><p>%s</p></div>', esc_html( $e->getMessage() ) );
         } );
     }
 } );

--- a/PetIA-app-bridge/includes/class-petia-app-bridge.php
+++ b/PetIA-app-bridge/includes/class-petia-app-bridge.php
@@ -2,7 +2,6 @@
 
 require_once __DIR__ . '/class-petia-token-manager.php';
 require_once __DIR__ . '/class-petia-admin.php';
-use Exception;
 
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
@@ -16,11 +15,8 @@ class PetIA_App_Bridge {
         try {
             $this->token_manager = new PetIA_Token_Manager();
         } catch ( Exception $e ) {
-            if ( function_exists( 'deactivate_plugins' ) ) {
-                deactivate_plugins( plugin_basename( dirname( __DIR__ ) . '/PetIA-app-bridge.php' ) );
-            }
             add_action( 'admin_notices', function() use ( $e ) {
-                echo '<div class="error"><p>' . esc_html( $e->getMessage() ) . '</p></div>';
+                printf( '<div class="error"><p>%s</p></div>', esc_html( $e->getMessage() ) );
             } );
             return;
         }


### PR DESCRIPTION
## Summary
- Remove self-deactivation and redundant Exception import in PetIA bridge class
- Guard plugin bootstrap with dependency checks and admin notices using printf
- Ensure autoloader presence without auto-running composer

## Testing
- `npm test`
- `php -l PetIA-app-bridge/includes/class-petia-app-bridge.php`
- `php -l PetIA-app-bridge/PetIA-app-bridge.php`


------
https://chatgpt.com/codex/tasks/task_e_68c090bbccb8832385de0f18db336963