### PR TITLE
Remove custom CORS handling

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -14,10 +14,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 
-if ( ! defined( 'PETIA_ALLOWED_ORIGINS' ) ) {
-    define( 'PETIA_ALLOWED_ORIGINS', '*' );
-}
-
 define( 'PETIA_ABSPATH', plugin_dir_path( __FILE__ ) );
 
 require_once PETIA_ABSPATH . 'includes/class-petia-token-manager.php';

--- a/PetIA-app-bridge/includes/class-petia-app-bridge.php
+++ b/PetIA-app-bridge/includes/class-petia-app-bridge.php
@@ -6,7 +6,6 @@ class PetIA_App_Bridge {
         $this->token_manager = new PetIA_Token_Manager();
         add_action( 'rest_api_init', [ $this, 'register_routes' ] );
         add_filter( 'rest_authentication_errors', [ $this, 'authenticate_requests' ] );
-        add_filter( 'rest_pre_serve_request', [ $this, 'cors_headers' ], 10, 3 );
 
         if ( is_admin() ) {
             new PetIA_Admin();
@@ -26,14 +25,6 @@ class PetIA_App_Bridge {
         ) $charset;";
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
-    }
-
-    public function cors_headers( $served, $result, $request ) {
-        header( 'Access-Control-Allow-Origin: ' . PETIA_ALLOWED_ORIGINS );
-        header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
-        header( 'Access-Control-Allow-Credentials: true' );
-        header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
-        return $served;
     }
 
     public function authenticate_requests( $result ) {


### PR DESCRIPTION
## Summary
- Delegate CORS management to WordPress by removing custom headers in PetIA App Bridge

## Testing
- `php -l PetIA-app-bridge/includes/class-petia-app-bridge.php`
- `php -l PetIA-app-bridge/PetIA-app-bridge.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09c13b5288323832cbb3c7e2440c2