### PR TITLE
Remove custom CORS handling and restore access control table

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -14,10 +14,6 @@ if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
     require_once __DIR__ . '/vendor/autoload.php';
 }
 
-if ( ! defined( 'PETIA_ALLOWED_ORIGINS' ) ) {
-    define( 'PETIA_ALLOWED_ORIGINS', '*' );
-}
-
 define( 'PETIA_ABSPATH', plugin_dir_path( __FILE__ ) );
 
 require_once PETIA_ABSPATH . 'includes/class-petia-token-manager.php';

--- a/PetIA-app-bridge/includes/class-petia-admin.php
+++ b/PetIA-app-bridge/includes/class-petia-admin.php
@@ -1,28 +1,95 @@
 <?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
 class PetIA_Admin {
     public function __construct() {
-        add_action( 'admin_menu', [ $this, 'register_menu' ] );
+        add_action( 'admin_menu', [ $this, 'register_admin_page' ] );
     }
 
-    public function register_menu() {
-        add_menu_page( 'PetIA Bridge', 'PetIA Bridge', 'manage_options', 'petia-bridge', [ $this, 'render_page' ] );
+    public function register_admin_page() {
+        add_menu_page(
+            __( 'PetIA App Bridge', 'petia-app-bridge' ),
+            __( 'PetIA Bridge', 'petia-app-bridge' ),
+            'manage_options',
+            'petia-app-bridge',
+            [ $this, 'render_admin_page' ]
+        );
     }
 
-    public function render_page() {
-        $tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'access';
-        echo '<div class="wrap"><h1>PetIA Bridge</h1><h2 class="nav-tab-wrapper">';
-        echo '<a href="?page=petia-bridge&tab=access" class="nav-tab' . ( 'access' === $tab ? ' nav-tab-active' : '' ) . '">Access Control</a>';
-        echo '<a href="?page=petia-bridge&tab=tests" class="nav-tab' . ( 'tests' === $tab ? ' nav-tab-active' : '' ) . '">Run Tests</a>';
+    public function render_admin_page() {
+        $tab      = isset( $_GET['tab'] ) ? sanitize_key( wp_unslash( $_GET['tab'] ) ) : 'access';
+        $base_url = menu_page_url( 'petia-app-bridge', false );
+
+        echo '<div class="wrap">';
+        echo '<h1>' . esc_html__( 'PetIA App Bridge', 'petia-app-bridge' ) . '</h1>';
+        echo '<h2 class="nav-tab-wrapper">';
+        echo '<a href="' . esc_url( add_query_arg( 'tab', 'access', $base_url ) ) . '" class="nav-tab ' . ( 'tests' !== $tab ? 'nav-tab-active' : '' ) . '">' . esc_html__( 'Access Control', 'petia-app-bridge' ) . '</a>';
+        echo '<a href="' . esc_url( add_query_arg( 'tab', 'tests', $base_url ) ) . '" class="nav-tab ' . ( 'tests' === $tab ? 'nav-tab-active' : '' ) . '">' . esc_html__( 'Run Tests', 'petia-app-bridge' ) . '</a>';
         echo '</h2>';
+
         if ( 'tests' === $tab ) {
-            if ( isset( $_POST['run-tests'] ) ) {
-                $output = esc_html( shell_exec( 'npm test 2>&1' ) );
-                echo '<pre>' . $output . '</pre>';
-            }
-            echo '<form method="post"><p><button class="button button-primary" name="run-tests">Run Node Tests</button></p></form>';
+            $this->render_tests_tab();
         } else {
-            echo '<p>Manage user access periods here.</p>';
+            $this->render_access_tab();
         }
         echo '</div>';
+    }
+
+    private function render_access_tab() {
+        if (
+            isset( $_POST['petia_access_nonce'] ) &&
+            wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['petia_access_nonce'] ) ), 'petia_save_access' )
+        ) {
+            $users = get_users( [ 'fields' => [ 'ID' ] ] );
+            global $wpdb;
+            $table = $wpdb->prefix . 'petia_app_bridge_access';
+            foreach ( $users as $user ) {
+                $allowed    = isset( $_POST['access'][ $user->ID ] ) ? 1 : 0;
+                $start_date = isset( $_POST['start_date'][ $user->ID ] ) && '' !== $_POST['start_date'][ $user->ID ]
+                    ? sanitize_text_field( wp_unslash( $_POST['start_date'][ $user->ID ] ) ) . ' 00:00:00'
+                    : current_time( 'mysql' );
+                $end_date   = isset( $_POST['end_date'][ $user->ID ] ) && '' !== $_POST['end_date'][ $user->ID ]
+                    ? sanitize_text_field( wp_unslash( $_POST['end_date'][ $user->ID ] ) ) . ' 23:59:59'
+                    : '9999-12-31 23:59:59';
+                $wpdb->replace(
+                    $table,
+                    [
+                        'user_id'    => $user->ID,
+                        'allowed'    => $allowed,
+                        'start_date' => $start_date,
+                        'end_date'   => $end_date,
+                    ],
+                    [ '%d', '%d', '%s', '%s' ]
+                );
+            }
+            echo '<div class="updated"><p>' . esc_html__( 'Settings saved.', 'petia-app-bridge' ) . '</p></div>';
+        }
+
+        $users = get_users();
+        global $wpdb;
+        $table = $wpdb->prefix . 'petia_app_bridge_access';
+
+        echo '<form method="post">';
+        wp_nonce_field( 'petia_save_access', 'petia_access_nonce' );
+        echo '<table class="widefat"><thead><tr><th>' . esc_html__( 'User', 'petia-app-bridge' ) . '</th><th>' . esc_html__( 'Allowed', 'petia-app-bridge' ) . '</th><th>' . esc_html__( 'Start Date', 'petia-app-bridge' ) . '</th><th>' . esc_html__( 'End Date', 'petia-app-bridge' ) . '</th></tr></thead><tbody>';
+        foreach ( $users as $user ) {
+            $row     = $wpdb->get_row( $wpdb->prepare( "SELECT allowed, start_date, end_date FROM $table WHERE user_id = %d", $user->ID ) );
+            $allowed = $row ? $row->allowed : null;
+            $checked = ( null === $allowed || $allowed ) ? 'checked' : '';
+            $start_v = $row ? substr( $row->start_date, 0, 10 ) : '';
+            $end_v   = $row ? substr( $row->end_date, 0, 10 ) : '9999-12-31';
+            echo '<tr><td>' . esc_html( $user->user_login ) . '</td><td><input type="checkbox" name="access[' . intval( $user->ID ) . ']" value="1" ' . $checked . '></td><td><input type="date" name="start_date[' . intval( $user->ID ) . ']" value="' . esc_attr( $start_v ) . '"></td><td><input type="date" name="end_date[' . intval( $user->ID ) . ']" value="' . esc_attr( $end_v ) . '"></td></tr>';
+        }
+        echo '</tbody></table><p><input type="submit" class="button-primary" value="' . esc_attr__( 'Save Changes', 'petia-app-bridge' ) . '"></p></form>';
+    }
+
+    private function render_tests_tab() {
+        if ( isset( $_POST['run-tests'] ) ) {
+            $output = esc_html( shell_exec( 'npm test 2>&1' ) );
+            echo '<pre>' . $output . '</pre>';
+        }
+        echo '<form method="post"><p><button class="button button-primary" name="run-tests">' . esc_html__( 'Run Node Tests', 'petia-app-bridge' ) . '</button></p></form>';
     }
 }

--- a/PetIA-app-bridge/includes/class-petia-app-bridge.php
+++ b/PetIA-app-bridge/includes/class-petia-app-bridge.php
@@ -6,7 +6,6 @@ class PetIA_App_Bridge {
         $this->token_manager = new PetIA_Token_Manager();
         add_action( 'rest_api_init', [ $this, 'register_routes' ] );
         add_filter( 'rest_authentication_errors', [ $this, 'authenticate_requests' ] );
-        add_filter( 'rest_pre_serve_request', [ $this, 'cors_headers' ], 10, 3 );
 
         if ( is_admin() ) {
             new PetIA_Admin();
@@ -26,14 +25,6 @@ class PetIA_App_Bridge {
         ) $charset;";
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
-    }
-
-    public function cors_headers( $served, $result, $request ) {
-        header( 'Access-Control-Allow-Origin: ' . PETIA_ALLOWED_ORIGINS );
-        header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
-        header( 'Access-Control-Allow-Credentials: true' );
-        header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
-        return $served;
     }
 
     public function authenticate_requests( $result ) {


### PR DESCRIPTION
## Summary
- Delegate CORS management to WordPress by removing custom headers in PetIA App Bridge
- Reinstate admin user access control table with access toggle and validity dates

## Testing
- `php -l PetIA-app-bridge/includes/class-petia-admin.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c09c13b5288323832cbb3c7e2440c2