### PR TITLE
Store auth token in sessionStorage

### DIFF
--- a/PetIA/js/token.js
+++ b/PetIA/js/token.js
@@ -13,22 +13,16 @@ export function isTokenExpired(token) {
 }
 
 export function setToken(token) {
-  let cookie = `token=${token}; path=/; SameSite=Lax`;
-  if (location.protocol === 'https:') {
-    cookie += '; Secure';
-  }
-  document.cookie = cookie;
+  sessionStorage.setItem('token', token);
 }
 
 export function getToken() {
-  return document.cookie
-    .split(';')
-    .map(c => c.trim())
-    .find(c => c.startsWith('token='))
-    ?.split('=')[1] || '';
+  return sessionStorage.getItem('token') || '';
 }
 
 export function clearToken() {
+  sessionStorage.removeItem('token');
+  // Remove legacy cookie if present
   document.cookie = 'token=; Max-Age=0; path=/;';
 }
 

--- a/__tests__/token.test.js
+++ b/__tests__/token.test.js
@@ -14,10 +14,12 @@ describe('token utils', () => {
     expect(isTokenExpired(future)).toBe(false);
   });
 
-  test('clears cookie', () => {
+  test('clears stored token', () => {
     setToken('abc');
+    expect(sessionStorage.getItem('token')).toBe('abc');
     expect(getToken()).toBe('abc');
     clearToken();
     expect(getToken()).toBe('');
+    expect(sessionStorage.getItem('token')).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- store JWT token in sessionStorage rather than cookies to reduce exposure
- update tests to cover new token storage and clearing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b4d4b6d88323bb55df186e7af952