### PR TITLE
Implement order address and WooCommerce proxy endpoints

### DIFF
--- a/PetIA-app-bridge/README.md
+++ b/PetIA-app-bridge/README.md
@@ -4,7 +4,7 @@ Plugin de WordPress que expone endpoints REST para ser consumidos por la aplicac
 
 ## Características
 - Autenticación mediante tokens JWT con expiración de 24 h y revocación.
-- Endpoints de registro, inicio de sesión, perfil, productos y más bajo `/wp-json/petia-app-bridge/v1/`.
+- Endpoints de registro, inicio de sesión, perfil, productos, pedidos y más bajo `/wp-json/petia-app-bridge/v1/`.
 - Proxy genérico para WooCommerce.
 - Manejo de CORS configurable mediante la constante `PETIA_ALLOWED_ORIGINS` (por defecto `*`).
 - Panel de administración "PetIA Bridge" con pestañas para control de acceso y ejecución de pruebas Node.
@@ -16,3 +16,20 @@ Plugin de WordPress que expone endpoints REST para ser consumidos por la aplicac
 4. Activa el plugin desde el panel de WordPress.
 
 Las dependencias PHP necesarias ya están incluidas, por lo que no es necesario ejecutar `composer install`.
+
+## Endpoints disponibles
+
+- `POST /wp-json/petia-app-bridge/v1/register`
+- `POST /wp-json/petia-app-bridge/v1/login`
+- `POST /wp-json/petia-app-bridge/v1/logout`
+- `GET /wp-json/petia-app-bridge/v1/validate-token`
+- `POST /wp-json/petia-app-bridge/v1/password-reset-request`
+- `POST /wp-json/petia-app-bridge/v1/password-reset`
+- `GET /wp-json/petia-app-bridge/v1/profile`
+- `POST /wp-json/petia-app-bridge/v1/profile`
+- `GET /wp-json/petia-app-bridge/v1/order/<id>/addresses`
+- `POST /wp-json/petia-app-bridge/v1/order/<id>/addresses`
+- `GET /wp-json/petia-app-bridge/v1/product-categories`
+- `GET /wp-json/petia-app-bridge/v1/products`
+- `GET /wp-json/petia-app-bridge/v1/brands`
+- `* /wp-json/petia-app-bridge/v1/wc/<endpoint>` (proxy WooCommerce)


### PR DESCRIPTION
## Summary
- expose endpoints to read and update order billing and shipping addresses
- add WooCommerce REST API proxy
- document all available API routes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b4d0643c83239f3f81900d2cdf12