### PR TITLE
feat: make credentials optional in fetchWithAuth

### DIFF
--- a/PetIA/js/token.js
+++ b/PetIA/js/token.js
@@ -32,5 +32,6 @@ export async function fetchWithAuth(input, options = {}) {
   if (token) {
     headers.set('Authorization', `Bearer ${token}`);
   }
-  return fetch(input, { ...options, headers, credentials: 'include' });
+  // Consumers can supply `credentials` in options when cookies are needed
+  return fetch(input, { ...options, headers });
 }

--- a/__tests__/token.test.js
+++ b/__tests__/token.test.js
@@ -1,4 +1,6 @@
-import { parseToken, isTokenExpired, setToken, getToken, clearToken } from '../PetIA/js/token.js';
+import { jest } from '@jest/globals';
+import 'whatwg-fetch';
+import { parseToken, isTokenExpired, setToken, getToken, clearToken, fetchWithAuth } from '../PetIA/js/token.js';
 
 describe('token utils', () => {
   test('parses token payload', () => {
@@ -21,5 +23,22 @@ describe('token utils', () => {
     clearToken();
     expect(getToken()).toBe('');
     expect(sessionStorage.getItem('token')).toBeNull();
+  });
+});
+
+describe('fetchWithAuth', () => {
+  beforeEach(() => {
+    clearToken();
+    global.fetch = jest.fn().mockResolvedValue({ ok: true });
+  });
+
+  test('does not set credentials by default', async () => {
+    await fetchWithAuth('/test');
+    expect(global.fetch.mock.calls[0][1].credentials).toBeUndefined();
+  });
+
+  test('respects credentials option when provided', async () => {
+    await fetchWithAuth('/test', { credentials: 'include' });
+    expect(global.fetch.mock.calls[0][1].credentials).toBe('include');
   });
 });


### PR DESCRIPTION
## Summary
- allow fetchWithAuth consumers to supply credentials instead of always including cookies
- cover credential usage with new tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b71b32408323b733e0566e105f30