### PR TITLE
Check token expiry before requests

### DIFF
--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -1,7 +1,13 @@
 import config from '../config.js';
-import { getToken, clearToken, fetchWithAuth } from './token.js';
+import { getToken, clearToken, fetchWithAuth, isTokenExpired } from './token.js';
 
 export async function apiRequest(endpoint, options = {}) {
+  const token = getToken();
+  if (token && isTokenExpired(token)) {
+    clearToken();
+    window.location.href = 'index.html';
+    throw new Error('Token expired');
+  }
   let url = endpoint;
   if (!/^https?:/i.test(endpoint)) {
     url = config.apiBaseUrl.replace(/\/$/, '') + endpoint;

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -3,6 +3,13 @@ import { apiRequest } from '../PetIA/js/api.js';
 import { setToken, getToken, clearToken } from '../PetIA/js/token.js';
 import 'whatwg-fetch';
 
+function createValidToken() {
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })
+  ).toString('base64');
+  return `aa.${payload}.bb`;
+}
+
 describe('apiRequest', () => {
   beforeEach(() => {
     clearToken();
@@ -10,7 +17,8 @@ describe('apiRequest', () => {
   });
 
   test('adds Authorization header', async () => {
-    setToken('abc');
+    const token = createValidToken();
+    setToken(token);
     global.fetch.mockResolvedValue({
       status: 200,
       headers: new Headers({ 'content-type': 'application/json' }),
@@ -18,11 +26,11 @@ describe('apiRequest', () => {
     });
     await apiRequest('/test');
     const headers = global.fetch.mock.calls[0][1].headers;
-    expect(headers.get('Authorization')).toBe('Bearer abc');
+    expect(headers.get('Authorization')).toBe(`Bearer ${token}`);
   });
 
   test('clears token and redirects on 401', async () => {
-    setToken('abc');
+    setToken(createValidToken());
     delete window.location;
     window.location = { href: '' };
     global.fetch.mockResolvedValue({

--- a/__tests__/error.test.js
+++ b/__tests__/error.test.js
@@ -3,6 +3,13 @@ import { apiRequest } from '../PetIA/js/api.js';
 import { parseToken, setToken, clearToken } from '../PetIA/js/token.js';
 import 'whatwg-fetch';
 
+function createValidToken() {
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1000) + 3600 })
+  ).toString('base64');
+  return `aa.${payload}.bb`;
+}
+
 describe('error handling', () => {
   beforeEach(() => {
     clearToken();
@@ -14,7 +21,7 @@ describe('error handling', () => {
   });
 
   test('apiRequest throws when body contains error', async () => {
-    setToken('abc');
+    setToken(createValidToken());
     global.fetch.mockResolvedValue({
       status: 200,
       headers: new Headers({ 'content-type': 'application/json' }),


### PR DESCRIPTION
## Summary
- verify token expiry at start of `apiRequest`
- redirect to login when token expired
- adjust tests to use valid tokens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0b728f48c8323a80fe7e00d74034b