### PR TITLE
Handle API response errors and update tests

### DIFF
--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -9,50 +9,54 @@ describe('apiRequest', () => {
     global.fetch = jest.fn();
   });
 
-  test('adds Authorization header', async () => {
-    setToken('abc');
-    global.fetch.mockResolvedValue({
-      status: 200,
-      headers: new Headers({ 'content-type': 'application/json' }),
-      json: async () => ({ ok: true }),
+    test('adds Authorization header', async () => {
+      setToken('abc');
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ ok: true }),
+      });
+      await apiRequest('/test');
+      const headers = global.fetch.mock.calls[0][1].headers;
+      expect(headers.get('Authorization')).toBe('Bearer abc');
     });
-    await apiRequest('/test');
-    const headers = global.fetch.mock.calls[0][1].headers;
-    expect(headers.get('Authorization')).toBe('Bearer abc');
-  });
 
-  test('clears token and redirects on 401', async () => {
-    setToken('abc');
-    delete window.location;
-    window.location = { href: '' };
-    global.fetch.mockResolvedValue({
-      status: 401,
-      headers: new Headers({ 'content-type': 'application/json' }),
-      json: async () => ({ error: 'Unauthorized' }),
+    test('clears token and redirects on 401', async () => {
+      setToken('abc');
+      delete window.location;
+      window.location = { href: '' };
+      global.fetch.mockResolvedValue({
+        status: 401,
+        ok: false,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ message: 'Unauthorized' }),
+      });
+      await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
+      expect(getToken()).toBe('');
+      expect(window.location.href).toBe('index.html');
     });
-    await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
-    expect(getToken()).toBe('');
-    expect(window.location.href).toBe('index.html');
-  });
 
-  test('401 without token does not redirect', async () => {
-    delete window.location;
-    window.location = { href: '' };
-    global.fetch.mockResolvedValue({
-      status: 401,
-      headers: new Headers({ 'content-type': 'application/json' }),
-      json: async () => ({ error: 'Unauthorized' }),
+    test('401 without token does not redirect', async () => {
+      delete window.location;
+      window.location = { href: '' };
+      global.fetch.mockResolvedValue({
+        status: 401,
+        ok: false,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ message: 'Unauthorized' }),
+      });
+      await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
+      expect(window.location.href).toBe('');
     });
-    await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
-    expect(window.location.href).toBe('');
-  });
 
-  test('throws on non JSON response', async () => {
-    global.fetch.mockResolvedValue({
-      status: 200,
-      headers: new Headers({ 'content-type': 'text/html' }),
-      json: async () => ({ ok: true }),
+    test('throws on non JSON response', async () => {
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: new Headers({ 'content-type': 'text/html' }),
+        json: async () => ({ ok: true }),
+      });
+      await expect(apiRequest('/test')).rejects.toThrow('Invalid JSON');
     });
-    await expect(apiRequest('/test')).rejects.toThrow('Invalid JSON');
   });
-});

--- a/__tests__/error.test.js
+++ b/__tests__/error.test.js
@@ -3,7 +3,7 @@ import { apiRequest } from '../PetIA/js/api.js';
 import { parseToken, setToken, clearToken } from '../PetIA/js/token.js';
 import 'whatwg-fetch';
 
-describe('error handling', () => {
+  describe('error handling', () => {
   beforeEach(() => {
     clearToken();
     global.fetch = jest.fn();
@@ -13,13 +13,14 @@ describe('error handling', () => {
     expect(parseToken('invalid')).toBeNull();
   });
 
-  test('apiRequest throws when body contains error', async () => {
-    setToken('abc');
-    global.fetch.mockResolvedValue({
-      status: 200,
-      headers: new Headers({ 'content-type': 'application/json' }),
-      json: async () => ({ error: 'fail' }),
+    test('apiRequest returns body even if it contains error field', async () => {
+      setToken('abc');
+      global.fetch.mockResolvedValue({
+        status: 200,
+        ok: true,
+        headers: new Headers({ 'content-type': 'application/json' }),
+        json: async () => ({ error: 'fail' }),
+      });
+      await expect(apiRequest('/test')).resolves.toEqual({ error: 'fail' });
     });
-    await expect(apiRequest('/test')).rejects.toThrow('fail');
   });
-});


### PR DESCRIPTION
## Summary
- Ensure apiRequest throws with server message or status text when response is not ok
- Redirect on both 401 and 403 responses and drop unused data.error check
- Update unit tests for new error handling

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b742d808832394e74b1245d38ac1