### PR TITLE
feat: allow login via email

### DIFF
--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -7,7 +7,7 @@
 <body>
   <h1>Login</h1>
   <form id="loginForm">
-    <input type="text" id="username" placeholder="Username" />
+    <input type="email" id="email" placeholder="Email" />
     <input type="password" id="password" placeholder="Password" />
     <button type="submit">Login</button>
   </form>
@@ -20,7 +20,7 @@
       const res = await fetch(config.apiBaseUrl + config.endpoints.login, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ username: username.value, password: password.value }),
+        body: JSON.stringify({ email: email.value, password: password.value }),
       });
       const token = res.headers.get('Authorization')?.split(' ')[1];
       if (token) {


### PR DESCRIPTION
## Summary
- swap username field for email field in login page
- verify email and password in login handler before creating token

## Testing
- `npm test` *(fails: unexpected token in __tests__/api.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c0bb4268d883238001dadca88fcf76