### PR TITLE
Handle CORS and preflight requests

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -31,7 +31,28 @@ class App_Bridge {
     }
 
     public function send_cors_headers( $served, $result, $request ) {
+        $origin = get_http_origin();
+        if ( $origin ) {
+            if ( rest_is_allowed_cors( $origin ) ) {
+                header( 'Access-Control-Allow-Origin: ' . esc_url_raw( $origin ) );
+                header( 'Vary: Origin' );
+            } else {
+                status_header( 403 );
+                return true;
+            }
+        } else {
+            header( 'Access-Control-Allow-Origin: *' );
+        }
+
+        header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
+        header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
         header( 'Access-Control-Expose-Headers: Authorization' );
+
+        if ( 'OPTIONS' === $request->get_method() ) {
+            status_header( 200 );
+            return true;
+        }
+
         return $served;
     }
 

--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -29,5 +29,8 @@ export async function apiRequest(endpoint, options = {}) {
     throw new Error('Invalid JSON response');
   }
   const data = await response.json();
+  if (data && data.error) {
+    throw new Error(data.error);
+  }
   return data;
 }

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -16,12 +16,12 @@ describe('apiRequest', () => {
     global.fetch = jest.fn();
   });
 
-
   test('adds Authorization header', async () => {
     const token = createValidToken();
     setToken(token);
     global.fetch.mockResolvedValue({
       status: 200,
+      ok: true,
       headers: new Headers({ 'content-type': 'application/json' }),
       json: async () => ({ ok: true }),
     });
@@ -36,30 +36,36 @@ describe('apiRequest', () => {
     window.location = { href: '' };
     global.fetch.mockResolvedValue({
       status: 401,
+      ok: false,
       headers: new Headers({ 'content-type': 'application/json' }),
-      json: async () => ({ error: 'Unauthorized' }),
+      json: async () => ({ message: 'Unauthorized' }),
     });
-
-    test('401 without token does not redirect', async () => {
-      delete window.location;
-      window.location = { href: '' };
-      global.fetch.mockResolvedValue({
-        status: 401,
-        ok: false,
-        headers: new Headers({ 'content-type': 'application/json' }),
-        json: async () => ({ message: 'Unauthorized' }),
-      });
-      await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
-      expect(window.location.href).toBe('');
-    });
-
-    test('throws on non JSON response', async () => {
-      global.fetch.mockResolvedValue({
-        status: 200,
-        ok: true,
-        headers: new Headers({ 'content-type': 'text/html' }),
-        json: async () => ({ ok: true }),
-      });
-      await expect(apiRequest('/test')).rejects.toThrow('Invalid JSON');
-    });
+    await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
+    expect(getToken()).toBe('');
+    expect(window.location.href).toBe('index.html');
   });
+
+  test('401 without token does not redirect', async () => {
+    delete window.location;
+    window.location = { href: '' };
+    global.fetch.mockResolvedValue({
+      status: 401,
+      ok: false,
+      headers: new Headers({ 'content-type': 'application/json' }),
+      json: async () => ({ message: 'Unauthorized' }),
+    });
+    await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
+    expect(window.location.href).toBe('');
+  });
+
+  test('throws on non JSON response', async () => {
+    global.fetch.mockResolvedValue({
+      status: 200,
+      ok: true,
+      headers: new Headers({ 'content-type': 'text/html' }),
+      json: async () => ({ ok: true }),
+    });
+    await expect(apiRequest('/test')).rejects.toThrow('Invalid JSON response');
+  });
+});
+

--- a/__tests__/error.test.js
+++ b/__tests__/error.test.js
@@ -25,7 +25,10 @@ describe('error handling', () => {
     setToken(createValidToken());
     global.fetch.mockResolvedValue({
       status: 200,
+      ok: true,
       headers: new Headers({ 'content-type': 'application/json' }),
       json: async () => ({ error: 'fail' }),
     });
+    await expect(apiRequest('/test')).rejects.toThrow('fail');
   });
+});


### PR DESCRIPTION
## Summary
- add CORS headers with origin validation for all REST responses
- handle OPTIONS preflight requests and send allowed methods/headers
- fix broken Jest tests and throw when API JSON includes an `error` field

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0be67c67c8323a1992f10dab65635