### PR TITLE
Implement custom CORS headers for REST API

### DIFF
--- a/PetIA-app-bridge/PetIA-app-bridge.php
+++ b/PetIA-app-bridge/PetIA-app-bridge.php
@@ -12,6 +12,52 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 require_once __DIR__ . '/vendor/autoload.php';
 
+/**
+ * Send CORS headers for REST responses and preflight requests.
+ *
+ * @param bool         $served  Whether the request has already been served.
+ * @param WP_HTTP_Response $result  Result to send to the client. Unused here.
+ * @param WP_REST_Request $request The REST request.
+ *
+ * @return bool The original $served value.
+ */
+function labotica_rest_cors( $served = false, $result = null, $request = null ) {
+    $origin          = isset( $_SERVER['HTTP_ORIGIN'] ) ? $_SERVER['HTTP_ORIGIN'] : '';
+    $allowed_origins = [
+        'http://localhost',
+        'http://localhost:3000',
+    ];
+
+    if ( $origin && in_array( $origin, $allowed_origins, true ) ) {
+        header( 'Access-Control-Allow-Origin: ' . $origin );
+    }
+
+    header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
+    header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
+    header( 'Access-Control-Expose-Headers: Authorization' );
+    header( 'Access-Control-Allow-Credentials: true' );
+
+    return $served;
+}
+
+add_action(
+    'rest_api_init',
+    function () {
+        add_filter( 'rest_pre_serve_request', 'labotica_rest_cors', 10, 3 );
+    }
+);
+
+add_action(
+    'init',
+    function () {
+        if ( 'OPTIONS' === $_SERVER['REQUEST_METHOD'] ) {
+            labotica_rest_cors();
+            status_header( 200 );
+            exit;
+        }
+    }
+);
+
 function petia_app_bridge_init() {
     new PetIA\App_Bridge();
 }

--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -8,7 +8,6 @@ class App_Bridge {
         $this->token_manager = new Token_Manager();
         add_action( 'rest_api_init', [ $this, 'register_routes' ] );
         add_filter( 'rest_authentication_errors', [ $this, 'authenticate_requests' ] );
-        add_filter( 'rest_pre_serve_request', [ $this, 'send_cors_headers' ], 15, 3 );
 
         if ( is_admin() ) {
             new Admin();
@@ -28,32 +27,6 @@ class App_Bridge {
         ) $charset;";
         require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
-    }
-
-    public function send_cors_headers( $served, $result, $request ) {
-        $origin = get_http_origin();
-        if ( $origin ) {
-            if ( rest_is_allowed_cors( $origin ) ) {
-                header( 'Access-Control-Allow-Origin: ' . esc_url_raw( $origin ) );
-                header( 'Vary: Origin' );
-            } else {
-                status_header( 403 );
-                return true;
-            }
-        } else {
-            header( 'Access-Control-Allow-Origin: *' );
-        }
-
-        header( 'Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS' );
-        header( 'Access-Control-Allow-Headers: Authorization, Content-Type' );
-        header( 'Access-Control-Expose-Headers: Authorization' );
-
-        if ( 'OPTIONS' === $request->get_method() ) {
-            status_header( 200 );
-            return true;
-        }
-
-        return $served;
     }
 
     public function authenticate_requests( $result ) {


### PR DESCRIPTION
## Summary
- add `labotica_rest_cors` for whitelisted origins and detailed CORS headers
- hook CORS handler to `rest_pre_serve_request` and handle OPTIONS requests early
- remove previous CORS filter from `App_Bridge`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0c89b6fb8832384acbdddb1274066