### PR TITLE
Validate profile response and handle login redirect

### DIFF
--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -29,7 +29,12 @@ export async function apiRequest(endpoint, options = {}) {
     throw new Error('Invalid JSON response');
   }
   const data = await response.json();
-  if (data && data.error) {
+  if (typeof data !== 'object' || data === null) {
+    clearToken();
+    window.location.href = 'index.html';
+    throw new Error('Invalid response');
+  }
+  if (data.error) {
     throw new Error(data.error);
   }
   return data;

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -32,7 +32,11 @@
           <p><strong>Email:</strong> ${data.email}</p>
         `;
       } catch (error) {
-        document.getElementById('profile').textContent = 'Error cargando perfil';
+        const profile = document.getElementById('profile');
+        profile.innerHTML = '<p>No se pudo cargar el perfil. Por favor inicia sesión.</p>';
+        setTimeout(() => {
+          window.location.href = 'index.html';
+        }, 2000);
       }
     }
 


### PR DESCRIPTION
## Summary
- Ensure API responses are objects and redirect to login when invalid
- Show a clear profile load error and redirect to index when fetch fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0f8eca330832393097c91f0a4f3f9