### PR TITLE
Segment store products by category with images

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -329,13 +329,26 @@ class App_Bridge {
         if ( ! function_exists( 'wc_get_products' ) ) {
             return [];
         }
-        $products = wc_get_products( [ 'limit' => 10 ] );
-        $data = [];
+        $args = [ 'limit' => -1 ];
+        $category = $request->get_param( 'category' );
+        if ( $category ) {
+            $args['tax_query'] = [
+                [
+                    'taxonomy' => 'product_cat',
+                    'field'    => 'term_id',
+                    'terms'    => array_map( 'intval', (array) $category ),
+                ],
+            ];
+        }
+        $products = wc_get_products( $args );
+        $data     = [];
         foreach ( $products as $product ) {
+            $image_id  = $product->get_image_id();
             $data[] = [
                 'id'    => $product->get_id(),
                 'name'  => $product->get_name(),
                 'price' => $product->get_price(),
+                'image' => $image_id ? wp_get_attachment_url( $image_id ) : '',
             ];
         }
         return $data;

--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -53,6 +53,29 @@ ul {
   padding: 0;
 }
 
+/* Store layout */
+#categories section {
+  margin-bottom: 2rem;
+}
+
+#categories ul {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+#categories li.product {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  width: 150px;
+  text-align: center;
+}
+
+#categories li.product img {
+  max-width: 100%;
+  height: auto;
+}
+
 /* Responsive adjustments */
 @media (min-width: 600px) {
   body {

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -1,0 +1,30 @@
+import config from '../config.js';
+import { apiRequest } from './api.js';
+
+async function load() {
+  const categories = await apiRequest(config.endpoints.productCategories);
+  const container = document.getElementById('categories');
+  for (const [id, name] of Object.entries(categories)) {
+    const section = document.createElement('section');
+    const heading = document.createElement('h2');
+    heading.textContent = name;
+    section.appendChild(heading);
+    const list = document.createElement('ul');
+    section.appendChild(list);
+    container.appendChild(section);
+
+    const products = await apiRequest(`${config.endpoints.products}?category=${id}`);
+    products.forEach(p => {
+      const li = document.createElement('li');
+      li.className = 'product';
+      li.innerHTML = `
+        <img src="${p.image}" alt="${p.name}" />
+        <div class="name">${p.name}</div>
+        <div class="price">${p.price}</div>
+      `;
+      list.appendChild(li);
+    });
+  }
+}
+
+load();

--- a/PetIA/store.html
+++ b/PetIA/store.html
@@ -14,21 +14,8 @@
     <a href="#" id="logout-link">Logout</a>
   </nav>
   <h1>Store</h1>
-  <ul id="products"></ul>
+  <div id="categories"></div>
   <script type="module" src="./js/logout.js"></script>
-  <script type="module">
-    import config from './config.js';
-    import { apiRequest } from './js/api.js';
-    async function load() {
-      const data = await apiRequest(config.endpoints.products);
-      const list = document.getElementById('products');
-      data.forEach(p => {
-        const li = document.createElement('li');
-        li.textContent = `${p.name} - ${p.price}`;
-        list.appendChild(li);
-      });
-    }
-    load();
-  </script>
+  <script type="module" src="./js/store.js"></script>
 </body>
 </html>

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -32,7 +32,16 @@
           <p><strong>Email:</strong> ${data.email}</p>
         `;
       } catch (error) {
-        document.getElementById('profile').textContent = 'Error cargando perfil';
+        console.error('Perfil:', error);
+        let message;
+        if (/network|fetch/i.test(error.message)) {
+          message = 'Error de red al cargar el perfil';
+        } else if (/token|unauthorized|forbidden|auth/i.test(error.message)) {
+          message = 'Error de autenticación. Inicia sesión nuevamente.';
+        } else {
+          message = 'Respuesta inesperada del servidor.';
+        }
+        document.getElementById('profile').textContent = message;
       }
     }
 


### PR DESCRIPTION
## Summary
- Expand products endpoint to support category filtering and include product images
- Display store items grouped by category with images and prices
- Style store layout similar to WooCommerce's grid

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0fdec43d883238d053b995216ebd0