### PR TITLE
Set current user from JWT token

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -3,9 +3,11 @@ namespace PetIA;
 
 class App_Bridge {
     private $token_manager;
+    private $decoded_token;
 
     public function __construct() {
         $this->token_manager = new Token_Manager();
+        add_filter( 'determine_current_user', [ $this, 'determine_current_user' ], 20 );
         add_action( 'rest_api_init', [ $this, 'register_routes' ] );
         add_filter( 'rest_authentication_errors', [ $this, 'authenticate_requests' ] );
 
@@ -42,16 +44,20 @@ class App_Bridge {
             return $result;
         }
         try {
-            $decoded = $this->token_manager->decode_token( $token );
-            if ( $this->token_manager->is_token_revoked( $decoded->jti ) ) {
+            $this->decoded_token = $this->decoded_token ?: $this->token_manager->decode_token( $token );
+            $user_id             = (int) $this->decoded_token->data->user_id;
+            if ( ! get_user_by( 'id', $user_id ) ) {
+                return new \WP_Error( 'invalid_user', 'User not found', [ 'status' => 401 ] );
+            }
+            if ( $this->token_manager->is_token_revoked( $this->decoded_token->jti ) ) {
                 return new \WP_Error( 'token_revoked', 'Token revoked', [ 'status' => 401 ] );
             }
             global $wpdb;
-            $table   = $wpdb->prefix . 'petia_app_bridge_access';
-            $access  = $wpdb->get_row(
+            $table  = $wpdb->prefix . 'petia_app_bridge_access';
+            $access = $wpdb->get_row(
                 $wpdb->prepare(
                     "SELECT allowed, start_date, end_date FROM $table WHERE user_id = %d",
-                    $decoded->data->user_id
+                    $user_id
                 )
             );
             $now = current_time( 'timestamp' );
@@ -64,10 +70,30 @@ class App_Bridge {
                 return new \WP_Error( 'forbidden', 'User not allowed', [ 'status' => 403 ] );
             }
 
-            wp_set_current_user( $decoded->data->user_id );
             return $result;
         } catch ( \Exception $e ) {
             return new \WP_Error( 'invalid_token', $e->getMessage(), [ 'status' => 401 ] );
+        }
+    }
+
+    public function determine_current_user( $user_id ) {
+        if ( $user_id ) {
+            return $user_id;
+        }
+        $token = $this->token_manager->get_authorization_header();
+        if ( ! $token ) {
+            return $user_id;
+        }
+        try {
+            $this->decoded_token = $this->token_manager->decode_token( $token );
+            $user_id             = (int) $this->decoded_token->data->user_id;
+            if ( get_user_by( 'id', $user_id ) ) {
+                wp_set_current_user( $user_id );
+                return $user_id;
+            }
+            return 0;
+        } catch ( \Exception $e ) {
+            return $user_id;
         }
     }
 
@@ -215,8 +241,31 @@ class App_Bridge {
             return new \WP_Error( 'no_token', 'No token provided', [ 'status' => 401 ] );
         }
         try {
-            $decoded = $this->token_manager->decode_token( $token );
-            return [ 'valid' => true, 'user_id' => $decoded->data->user_id ];
+            $decoded  = $this->token_manager->decode_token( $token );
+            $user_id  = (int) $decoded->data->user_id;
+            $user     = get_user_by( 'id', $user_id );
+            if ( ! $user ) {
+                return new \WP_Error( 'invalid_user', 'User not found', [ 'status' => 401 ] );
+            }
+            global $wpdb;
+            $table  = $wpdb->prefix . 'petia_app_bridge_access';
+            $access = $wpdb->get_row(
+                $wpdb->prepare(
+                    "SELECT allowed, start_date, end_date FROM $table WHERE user_id = %d",
+                    $user_id
+                )
+            );
+            $now = current_time( 'timestamp' );
+            if (
+                empty( $access ) ||
+                (int) $access->allowed !== 1 ||
+                ( $access->start_date && $now < strtotime( $access->start_date ) ) ||
+                ( $access->end_date && $now > strtotime( $access->end_date ) )
+            ) {
+                return new \WP_Error( 'forbidden', 'User not allowed', [ 'status' => 403 ] );
+            }
+
+            return [ 'valid' => true, 'user_id' => $user_id ];
         } catch ( \Exception $e ) {
             return new \WP_Error( 'invalid_token', $e->getMessage(), [ 'status' => 401 ] );
         }


### PR DESCRIPTION
## Summary
- ensure REST requests set the current user only when the JWT maps to an existing WordPress user
- reuse the decoded token to check revocation and access rules and to validate the token endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c10d9418ac8323a6f0e0e1f638aad2