### PR TITLE
feat: expose parent IDs in product category endpoint

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -371,7 +371,15 @@ class App_Bridge {
             return [];
         }
         $terms = get_terms( [ 'taxonomy' => 'product_cat', 'hide_empty' => false ] );
-        return wp_list_pluck( $terms, 'name', 'term_id' );
+        $data  = array_map(
+            fn( $t ) => [
+                'id'     => $t->term_id,
+                'name'   => $t->name,
+                'parent' => $t->parent,
+            ],
+            $terms
+        );
+        return $data;
     }
 
     public function handle_products( \WP_REST_Request $request ) {

--- a/PetIA/README.md
+++ b/PetIA/README.md
@@ -10,6 +10,19 @@ Aplicación web estática que consume los endpoints del plugin PetIA App Bridge.
 2. Ajusta `API_BASE_URL` si tu WordPress corre en otra URL.
 3. Abre `index.html` para iniciar sesión.
 
+## Categorías de productos
+
+El endpoint `/wp-json/petia-app-bridge/v1/product-categories` ahora devuelve un arreglo de objetos con la forma:
+
+```json
+[
+  { "id": 1, "name": "Perros", "parent": 0 },
+  { "id": 2, "name": "Pienso", "parent": 1 }
+]
+```
+
+Con esta estructura `store.js` puede filtrar las categorías principales mediante `parent === 0` y obtener subcategorías dinámicamente.
+
 ## Pruebas
 Ejecuta en la raíz del repositorio:
 ```bash


### PR DESCRIPTION
## Summary
- return id, name and parent for each product category
- document category response format for store.js filtering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1c372550083238da6ce57811c4e6d