### PR TITLE
Refactor store UI with category tabs

### DIFF
--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -54,24 +54,45 @@ ul {
 }
 
 /* Store layout */
-#categories section {
+.tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.tab {
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+}
+
+.tab.active {
+  border-bottom: 2px solid #333;
+  font-weight: bold;
+}
+
+.tab-panel {
+  display: none;
   margin-bottom: 2rem;
 }
 
-#categories ul {
+.tab-panel.active {
+  display: block;
+}
+
+.tab-panel ul {
   display: flex;
   flex-wrap: wrap;
   gap: 1rem;
 }
 
-#categories li.product {
+.tab-panel li.product {
   border: 1px solid #ccc;
   padding: 0.5rem;
   width: 150px;
   text-align: center;
 }
 
-#categories li.product img {
+.tab-panel li.product img {
   max-width: 100%;
   height: auto;
 }

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -1,30 +1,115 @@
 import config from '../config.js';
 import { apiRequest } from './api.js';
 
-async function load() {
-  const categories = await apiRequest(config.endpoints.productCategories);
-  const container = document.getElementById('categories');
-  for (const [id, name] of Object.entries(categories)) {
-    const section = document.createElement('section');
-    const heading = document.createElement('h2');
-    heading.textContent = name;
-    section.appendChild(heading);
-    const list = document.createElement('ul');
-    section.appendChild(list);
-    container.appendChild(section);
+const productsCache = new Map();
+let allCategories = [];
 
-    const products = await apiRequest(`${config.endpoints.products}?category=${id}`);
-    products.forEach(p => {
-      const li = document.createElement('li');
-      li.className = 'product';
-      li.innerHTML = `
-        <img src="${p.image}" alt="${p.name}" />
-        <div class="name">${p.name}</div>
-        <div class="price">${p.price}</div>
-      `;
-      list.appendChild(li);
-    });
+async function loadCategoryProducts(categoryId) {
+  const panel = document.getElementById(`panel-${categoryId}`);
+  if (!panel) return;
+  if (productsCache.has(categoryId)) {
+    renderProducts(productsCache.get(categoryId), panel);
+    return;
   }
+  panel.innerHTML = '<p>Cargando...</p>';
+  const products = await apiRequest(`${config.endpoints.products}?category=${categoryId}`);
+  productsCache.set(categoryId, products);
+  renderProducts(products, panel);
 }
 
-load();
+function renderProducts(products, panel) {
+  panel.innerHTML = '';
+  const list = document.createElement('ul');
+  panel.appendChild(list);
+  products.forEach(p => {
+    const li = document.createElement('li');
+    li.className = 'product';
+    li.innerHTML = `
+      <img src="${p.image}" alt="${p.name}" />
+      <div class="name">${p.name}</div>
+      <div class="price">${p.price}</div>
+    `;
+    list.appendChild(li);
+  });
+}
+
+function renderCategories(categories) {
+  allCategories = categories;
+  const tabs = document.getElementById('category-tabs');
+  const content = document.getElementById('category-content');
+  categories
+    .filter(c => !c.parent)
+    .forEach(cat => {
+      const tab = document.createElement('div');
+      tab.className = 'tab';
+      tab.textContent = cat.name;
+      tab.dataset.id = cat.id;
+      tabs.appendChild(tab);
+
+      const panel = document.createElement('div');
+      panel.className = 'tab-panel';
+      panel.id = `panel-${cat.id}`;
+      content.appendChild(panel);
+
+      tab.addEventListener('click', () => {
+        tabs.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+        content.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+        tab.classList.add('active');
+        panel.classList.add('active');
+        renderSubcategories(cat.id);
+      });
+    });
+  const first = tabs.querySelector('.tab');
+  if (first) first.click();
+}
+
+function renderSubcategories(parentId) {
+  const panel = document.getElementById(`panel-${parentId}`);
+  if (!panel || panel.dataset.subRendered) return;
+  const subs = allCategories.filter(c => c.parent === parentId);
+  if (subs.length === 0) {
+    if (!productsCache.has(parentId)) {
+      loadCategoryProducts(parentId);
+    }
+    panel.dataset.subRendered = 'true';
+    return;
+  }
+  const tabs = document.createElement('div');
+  tabs.className = 'tabs';
+  const content = document.createElement('div');
+  panel.appendChild(tabs);
+  panel.appendChild(content);
+  subs.forEach(sub => {
+    const tab = document.createElement('div');
+    tab.className = 'tab';
+    tab.textContent = sub.name;
+    tab.dataset.id = sub.id;
+    tabs.appendChild(tab);
+
+    const subPanel = document.createElement('div');
+    subPanel.className = 'tab-panel';
+    subPanel.id = `panel-${sub.id}`;
+    content.appendChild(subPanel);
+
+    tab.addEventListener('click', () => {
+      tabs.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+      content.querySelectorAll('.tab-panel').forEach(p => p.classList.remove('active'));
+      tab.classList.add('active');
+      subPanel.classList.add('active');
+      if (!productsCache.has(sub.id)) {
+        loadCategoryProducts(sub.id);
+      }
+    });
+  });
+  const first = tabs.querySelector('.tab');
+  if (first) first.click();
+  panel.dataset.subRendered = 'true';
+}
+
+(async function init() {
+  const categories = await apiRequest(config.endpoints.productCategories);
+  renderCategories(categories);
+})();
+
+export { renderCategories, loadCategoryProducts, renderSubcategories };
+

--- a/PetIA/store.html
+++ b/PetIA/store.html
@@ -14,7 +14,8 @@
     <a href="#" id="logout-link">Logout</a>
   </nav>
   <h1>Store</h1>
-  <div id="categories"></div>
+  <div id="category-tabs" class="tabs"></div>
+  <div id="category-content"></div>
   <script type="module" src="./js/logout.js"></script>
   <script type="module" src="./js/store.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- implement tabbed category layout in store.html
- add base tab styles
- lazy-load products with caching and subcategory tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c412255c83239e2eb9dd26d17324