### PR TITLE
Add WooCommerce Store API proxy endpoint

### DIFF
--- a/PetIA-app-bridge/README.md
+++ b/PetIA-app-bridge/README.md
@@ -5,7 +5,7 @@ Plugin de WordPress que expone endpoints REST para ser consumidos por la aplicac
 ## Características
 - Autenticación mediante tokens JWT con expiración de 24 h y revocación.
 - Endpoints de registro, inicio de sesión, perfil, productos, pedidos y más bajo `/wp-json/petia-app-bridge/v1/`.
-- Proxy genérico para WooCommerce.
+- Proxy genérico para WooCommerce y Store API.
 - Manejo de CORS configurable mediante la opción `petia_app_bridge_allowed_origins` (admite `*` como comodín).
 - Panel de administración "PetIA Bridge" con pestañas para control de acceso y ejecución de pruebas Node.
 
@@ -33,3 +33,4 @@ Las dependencias PHP necesarias ya están incluidas, por lo que no es necesario 
 - `GET /wp-json/petia-app-bridge/v1/products`
 - `GET /wp-json/petia-app-bridge/v1/brands`
 - `* /wp-json/petia-app-bridge/v1/wc/<endpoint>` (proxy WooCommerce)
+- `* /wp-json/petia-app-bridge/v1/wc-store/<endpoint>` (proxy WooCommerce Store API)

--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -164,6 +164,11 @@ class App_Bridge {
             'callback' => [ $this, 'handle_brands' ],
             'permission_callback' => '__return_true',
         ] );
+        register_rest_route( $namespace, '/wc-store/(?P<endpoint>.*)', [
+            'methods' => [ 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ],
+            'callback' => [ $this, 'handle_wc_store_proxy' ],
+            'permission_callback' => '__return_true',
+        ] );
         register_rest_route( $namespace, '/wc/(?P<endpoint>.*)', [
             'methods' => [ 'GET', 'POST', 'PUT', 'PATCH', 'DELETE' ],
             'callback' => [ $this, 'handle_wc_proxy' ],
@@ -417,6 +422,29 @@ class App_Bridge {
         }
         $terms = get_terms( [ 'taxonomy' => 'product_brand', 'hide_empty' => false ] );
         return wp_list_pluck( $terms, 'name', 'term_id' );
+    }
+
+    public function handle_wc_store_proxy( \WP_REST_Request $request ) {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return new \WP_Error( 'woocommerce_missing', 'WooCommerce not available', [ 'status' => 501 ] );
+        }
+        $endpoint = ltrim( $request['endpoint'], '/' );
+        $method   = $request->get_method();
+        $proxy_request = new \WP_REST_Request( $method, '/wc/store/' . $endpoint );
+        $proxy_request->set_query_params( $request->get_query_params() );
+        foreach ( $request->get_headers() as $name => $values ) {
+            if ( 'host' === strtolower( $name ) ) {
+                continue;
+            }
+            foreach ( (array) $values as $value ) {
+                $proxy_request->set_header( $name, $value );
+            }
+        }
+        if ( in_array( $method, [ 'POST', 'PUT', 'PATCH' ], true ) ) {
+            $proxy_request->set_body( $request->get_body() );
+        }
+        $response = rest_do_request( $proxy_request );
+        return $response;
     }
 
     public function handle_wc_proxy( \WP_REST_Request $request ) {


### PR DESCRIPTION
## Summary
- expose wc-store proxy route for WooCommerce Store API
- implement handler to forward requests to /wc/store endpoints
- document new proxy route in plugin README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1ca3ddf6c83239e4790470e89e562