### PR TITLE
feat: add cart API utilities

### DIFF
--- a/PetIA/js/cart.js
+++ b/PetIA/js/cart.js
@@ -1,0 +1,30 @@
+import { apiRequest } from './api.js';
+
+export function getCart() {
+  return apiRequest('/wp-json/petia-app-bridge/v1/wc-store/cart');
+}
+
+export function addItem(productId, quantity) {
+  return apiRequest('/wc-store/cart/add-item', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ id: productId, quantity }),
+  });
+}
+
+export function updateItem(itemKey, quantity) {
+  return apiRequest('/wc-store/cart/update-item', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key: itemKey, quantity }),
+  });
+}
+
+export function removeItem(itemKey) {
+  return apiRequest('/wc-store/cart/remove-item', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ key: itemKey }),
+  });
+}
+


### PR DESCRIPTION
## Summary
- add cart API utilities for fetching and modifying store cart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1cbb638a0832388960984418d3b8a