### PR TITLE
feat: add cart page with checkout and item management

### DIFF
--- a/PetIA/cart.html
+++ b/PetIA/cart.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="css/styles.css" />
+  <title>PetIA Cart</title>
+</head>
+<body>
+  <nav>
+    <a href="chat.html">Chat</a>
+    <a href="store.html">Store</a>
+    <a href="cart.html">Cart</a>
+    <a href="user.html">Profile</a>
+    <a href="#" id="logout-link">Logout</a>
+  </nav>
+  <h1>Carrito</h1>
+  <div id="cart-container">
+    <table id="cart-table">
+      <thead>
+        <tr>
+          <th>Producto</th>
+          <th>Precio</th>
+          <th>Cantidad</th>
+          <th>Subtotal</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="cart-items"></tbody>
+    </table>
+    <p id="cart-empty" style="display:none">El carrito está vacío.</p>
+    <div class="cart-actions">
+      <button id="clear-cart">Vaciar carrito</button>
+      <button id="checkout-button">Finalizar compra</button>
+    </div>
+  </div>
+  <script type="module" src="./js/logout.js"></script>
+  <script type="module" src="./js/cart-page.js"></script>
+</body>
+</html>

--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -107,3 +107,32 @@ ul {
     max-width: 500px;
   }
 }
+
+/* Cart page */
+#cart-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+#cart-table th,
+#cart-table td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+#cart-table input[type='number'] {
+  width: 60px;
+}
+
+.cart-actions {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+#cart-empty {
+  text-align: center;
+  margin: 1rem 0;
+}

--- a/PetIA/js/cart-page.js
+++ b/PetIA/js/cart-page.js
@@ -1,0 +1,68 @@
+import { getCart, updateItem, removeItem } from './cart.js';
+
+async function renderCart() {
+  try {
+    const cart = await getCart();
+    const tbody = document.getElementById('cart-items');
+    const empty = document.getElementById('cart-empty');
+    const table = document.getElementById('cart-table');
+    const actions = document.querySelector('.cart-actions');
+    tbody.innerHTML = '';
+    if (!cart.items || cart.items.length === 0) {
+      table.style.display = 'none';
+      actions.style.display = 'none';
+      empty.style.display = 'block';
+      return;
+    }
+    table.style.display = '';
+    actions.style.display = 'flex';
+    empty.style.display = 'none';
+    cart.items.forEach(item => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${item.name}</td>
+        <td>${item.prices?.price ?? ''}</td>
+        <td><input type="number" min="1" value="${item.quantity}" /></td>
+        <td>${item.totals?.line_total ?? ''}</td>
+        <td><button class="remove">Eliminar</button></td>
+      `;
+      const qtyInput = tr.querySelector('input');
+      qtyInput.addEventListener('change', async () => {
+        const qty = parseInt(qtyInput.value, 10);
+        await updateItem(item.key, qty);
+        renderCart();
+      });
+      tr.querySelector('.remove').addEventListener('click', async () => {
+        await removeItem(item.key);
+        renderCart();
+      });
+      tbody.appendChild(tr);
+    });
+  } catch (error) {
+    console.error('Error al renderizar el carrito:', error);
+  }
+}
+
+async function clearCart() {
+  try {
+    const cart = await getCart();
+    await Promise.all((cart.items || []).map(i => removeItem(i.key)));
+    renderCart();
+  } catch (error) {
+    console.error('Error al vaciar el carrito:', error);
+  }
+}
+
+function checkout() {
+  window.location.href = '/checkout';
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document
+    .getElementById('clear-cart')
+    .addEventListener('click', clearCart);
+  document
+    .getElementById('checkout-button')
+    .addEventListener('click', checkout);
+  renderCart();
+});


### PR DESCRIPTION
## Summary
- add cart.html with table listing cart items and action buttons
- implement cart-page.js to render cart, update quantities, remove items, clear cart, and redirect to checkout
- extend styles.css with cart-specific table and layout styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1cc5e493c8323ba5011c8484ed2bf