### PR TITLE
feat: persist WooCommerce cart across sessions

### DIFF
--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -16,6 +16,7 @@
   <script type="module">
     import config from './config.js';
     import { setToken } from './js/token.js';
+    import { syncLocalCart, getCart, getCartKey } from './js/cart.js';
     const form = document.getElementById('loginForm');
     form.addEventListener('submit', async e => {
       e.preventDefault();
@@ -27,6 +28,19 @@
       const token = res.headers.get('Authorization')?.split(' ')[1];
       if (token) {
         setToken(token);
+        await syncLocalCart();
+        if (
+          typeof localStorage !== 'undefined' &&
+          localStorage.getItem('restoreCart') &&
+          getCartKey()
+        ) {
+          try {
+            await getCart();
+          } catch (err) {
+            console.error('Error restoring cart', err);
+          }
+          localStorage.removeItem('restoreCart');
+        }
         location.href = 'chat.html';
       }
     });

--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -4,6 +4,9 @@ import { getToken, clearToken, fetchWithAuth, isTokenExpired } from './token.js'
 export async function apiRequest(endpoint, options = {}) {
   const token = getToken();
   if (token && isTokenExpired(token)) {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('restoreCart', '1');
+    }
     clearToken();
     window.location.href = 'index.html';
     throw new Error('Token expired');
@@ -19,6 +22,9 @@ export async function apiRequest(endpoint, options = {}) {
     throw new Error('Network error');
   }
   if (response.status === 401 || response.status === 403) {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('restoreCart', '1');
+    }
     clearToken();
     window.location.href = 'index.html';
     throw new Error('Unauthorized');

--- a/PetIA/js/cart.js
+++ b/PetIA/js/cart.js
@@ -1,11 +1,87 @@
 import { apiRequest } from './api.js';
+import { getToken } from './token.js';
+
+// Local storage keys
+const CART_KEY_STORAGE = 'cart_key';
+const LOCAL_CART_STORAGE = 'local_cart';
+
+function getStoredCartKey() {
+  if (typeof localStorage === 'undefined') return null;
+  return localStorage.getItem(CART_KEY_STORAGE);
+}
+
+function storeCartKey(key) {
+  if (typeof localStorage === 'undefined' || !key) return;
+  localStorage.setItem(CART_KEY_STORAGE, key);
+}
+
+function buildEndpoint(endpoint) {
+  const cartKey = getStoredCartKey();
+  if (!cartKey) return endpoint;
+  const sep = endpoint.includes('?') ? '&' : '?';
+  return `${endpoint}${sep}cart_key=${encodeURIComponent(cartKey)}`;
+}
+
+function getLocalCart() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    return JSON.parse(localStorage.getItem(LOCAL_CART_STORAGE)) || [];
+  } catch {
+    return [];
+  }
+}
+
+function setLocalCart(items) {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.setItem(LOCAL_CART_STORAGE, JSON.stringify(items));
+}
+
+function clearLocalCart() {
+  if (typeof localStorage === 'undefined') return;
+  localStorage.removeItem(LOCAL_CART_STORAGE);
+}
+
+async function cartRequest(endpoint, options) {
+  const data = await apiRequest(buildEndpoint(endpoint), options);
+  if (data && data.cart_key) {
+    storeCartKey(data.cart_key);
+  }
+  return data;
+}
+
+export async function syncLocalCart() {
+  if (!getToken()) return;
+  const items = getLocalCart();
+  for (const item of items) {
+    await cartRequest('/wc-store/cart/add-item', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id: item.id, quantity: item.quantity }),
+    });
+  }
+  clearLocalCart();
+}
 
 export function getCart() {
-  return apiRequest('/wp-json/petia-app-bridge/v1/wc-store/cart');
+  if (!getToken()) {
+    return Promise.resolve({ items: getLocalCart() });
+  }
+  return cartRequest('/wp-json/petia-app-bridge/v1/wc-store/cart');
 }
 
 export function addItem(productId, quantity) {
-  return apiRequest('/wc-store/cart/add-item', {
+  if (!getToken()) {
+    const cart = getLocalCart();
+    const existing = cart.find(i => i.id === productId);
+    if (existing) {
+      existing.quantity += quantity;
+    } else {
+      cart.push({ id: productId, quantity, key: String(productId) });
+    }
+    setLocalCart(cart);
+    return Promise.resolve({ items: cart });
+  }
+  return cartRequest('/wc-store/cart/add-item', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ id: productId, quantity }),
@@ -13,7 +89,14 @@ export function addItem(productId, quantity) {
 }
 
 export function updateItem(itemKey, quantity) {
-  return apiRequest('/wc-store/cart/update-item', {
+  if (!getToken()) {
+    const cart = getLocalCart();
+    const item = cart.find(i => String(i.key || i.id) === String(itemKey));
+    if (item) item.quantity = quantity;
+    setLocalCart(cart);
+    return Promise.resolve({ items: cart });
+  }
+  return cartRequest('/wc-store/cart/update-item', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ key: itemKey, quantity }),
@@ -21,10 +104,19 @@ export function updateItem(itemKey, quantity) {
 }
 
 export function removeItem(itemKey) {
-  return apiRequest('/wc-store/cart/remove-item', {
+  if (!getToken()) {
+    const cart = getLocalCart().filter(
+      i => String(i.key || i.id) !== String(itemKey)
+    );
+    setLocalCart(cart);
+    return Promise.resolve({ items: cart });
+  }
+  return cartRequest('/wc-store/cart/remove-item', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ key: itemKey }),
   });
 }
+
+export { getStoredCartKey as getCartKey };
 

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -14,6 +14,7 @@ describe('apiRequest', () => {
   beforeEach(() => {
     clearToken();
     global.fetch = jest.fn();
+    localStorage.clear();
   });
 
   test('adds Authorization header', async () => {
@@ -43,6 +44,7 @@ describe('apiRequest', () => {
     await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
     expect(getToken()).toBe('');
     expect(window.location.href).toBe('index.html');
+    expect(localStorage.getItem('restoreCart')).toBe('1');
   });
 
   test('401 without token redirects', async () => {
@@ -56,6 +58,7 @@ describe('apiRequest', () => {
     });
     await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
     expect(window.location.href).toBe('index.html');
+    expect(localStorage.getItem('restoreCart')).toBe('1');
   });
 
   test('throws Network error on fetch failure', async () => {

--- a/__tests__/cart.test.js
+++ b/__tests__/cart.test.js
@@ -1,0 +1,36 @@
+import { jest } from '@jest/globals';
+
+describe('cart', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  test('stores cart_key from responses', async () => {
+    const mockApi = jest.fn(async () => ({ cart_key: 'abc123', items: [] }));
+    jest.unstable_mockModule('../PetIA/js/api.js', () => ({ apiRequest: mockApi }));
+    const { addItem, getCartKey } = await import('../PetIA/js/cart.js');
+    sessionStorage.setItem('token', 't');
+    await addItem(1, 1);
+    expect(getCartKey()).toBe('abc123');
+  });
+
+  test('sends cart_key in subsequent requests', async () => {
+    const first = jest.fn(async () => ({ cart_key: 'abc123', items: [] }));
+    jest.unstable_mockModule('../PetIA/js/api.js', () => ({ apiRequest: first }));
+    const { addItem } = await import('../PetIA/js/cart.js');
+    sessionStorage.setItem('token', 't');
+    await addItem(1, 1);
+
+    jest.resetModules();
+    const second = jest.fn(async () => ({ items: [] }));
+    jest.unstable_mockModule('../PetIA/js/api.js', () => ({ apiRequest: second }));
+    const { addItem: addItem2 } = await import('../PetIA/js/cart.js');
+    sessionStorage.setItem('token', 't');
+    await addItem2(2, 1);
+    const url = second.mock.calls[0][0];
+    expect(url).toMatch(/cart_key=abc123/);
+  });
+});
+


### PR DESCRIPTION
## Summary
- save WooCommerce cart key in localStorage and use it for subsequent cart API calls
- fallback to a local cart when unauthenticated and sync upon login
- restore cart after token expiration and login
- add unit tests for cart key persistence

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1cd6f6bd88323b53dec6673853641