### PR TITLE
feat: add cart actions to store

### DIFF
--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -1,5 +1,6 @@
 import config from '../config.js';
 import { apiRequest } from './api.js';
+import { addItem } from './cart.js';
 
 const loadedCategories = new Map();
 let allCategories = [];
@@ -28,7 +29,13 @@ function renderProducts(products, panel) {
       <img src="${p.image}" alt="${p.name}" />
       <div class="name">${p.name}</div>
       <div class="price">${p.price}</div>
+      <button class="add-cart">Añadir</button>
     `;
+    const btn = li.querySelector('.add-cart');
+    btn.addEventListener('click', async () => {
+      await addItem(p.id, 1);
+      alert('Producto agregado');
+    });
     list.appendChild(li);
   });
 }

--- a/PetIA/store.html
+++ b/PetIA/store.html
@@ -10,6 +10,7 @@
   <nav>
     <a href="chat.html">Chat</a>
     <a href="store.html">Store</a>
+    <a href="cart.html">Cart</a>
     <a href="user.html">Profile</a>
     <a href="#" id="logout-link">Logout</a>
   </nav>


### PR DESCRIPTION
## Summary
- add "Add to cart" button for store products wired to cart API
- link cart page from store navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1c2f42ac88323a3b4db07cd651724