### PR TITLE
Set current user on authenticated requests

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -69,6 +69,7 @@ class App_Bridge {
             ) {
                 return new \WP_Error( 'forbidden', 'User not allowed', [ 'status' => 403 ] );
             }
+            wp_set_current_user( $user_id );
 
             return $result;
         } catch ( \Exception $e ) {


### PR DESCRIPTION
## Summary
- ensure authenticated REST requests set the current user before returning

## Testing
- `npm test`
- `php test_profile.php` (simulated request to `/wp-json/petia-app-bridge/v1/profile` with Authorization header)


------
https://chatgpt.com/codex/tasks/task_e_68c1e1da30108323b9adb2f96740fb3b