### PR TITLE
Handle unauthenticated profile requests

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -301,8 +301,15 @@ class App_Bridge {
 
     public function handle_profile_get( \WP_REST_Request $request ) {
         $user = wp_get_current_user();
+        if ( 0 === $user->ID ) {
+            return new \WP_Error(
+                'authentication_required',
+                'Authentication required',
+                [ 'status' => 401 ]
+            );
+        }
         return [
-            'id'         => $user->ID,
+            'id'          => $user->ID,
             'username'    => $user->user_login,
             'display_name'=> $user->display_name,
             'email'       => $user->user_email,

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -37,7 +37,7 @@
         if (/network|fetch/i.test(error.message)) {
           message = 'Error de red al cargar el perfil';
         } else if (/token|unauthorized|forbidden|auth/i.test(error.message)) {
-          message = 'Error de autenticación. Inicia sesión nuevamente.';
+          message = 'Error de autenticación';
         } else {
           message = 'Respuesta inesperada del servidor.';
         }


### PR DESCRIPTION
## Summary
- return 401 error when requesting profile without authentication
- display "Error de autenticación" on profile page if profile request fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1e3fa8ed4832381a3dbc6b07c75d1