### PR TITLE
feat: allow handling auth errors without redirect

### DIFF
--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -1,7 +1,7 @@
 import config from '../config.js';
 import { getToken, clearToken, fetchWithAuth, isTokenExpired } from './token.js';
 
-export async function apiRequest(endpoint, options = {}) {
+export async function apiRequest(endpoint, { redirectOnAuthError = true, ...options } = {}) {
   const token = getToken();
   if (token && isTokenExpired(token)) {
     if (typeof localStorage !== 'undefined') {
@@ -26,7 +26,9 @@ export async function apiRequest(endpoint, options = {}) {
       localStorage.setItem('restoreCart', '1');
     }
     clearToken();
-    window.location.href = 'index.html';
+    if (redirectOnAuthError) {
+      window.location.href = 'index.html';
+    }
     throw new Error('Unauthorized');
   }
   if (!response.ok) {

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -22,7 +22,7 @@
 
     async function load() {
       try {
-        const data = await apiRequest(config.endpoints.profile);
+        const data = await apiRequest(config.endpoints.profile, { redirectOnAuthError: false });
         const profile = document.getElementById('profile');
         profile.innerHTML = `
           <p><strong>Usuario:</strong> ${data.username}</p>


### PR DESCRIPTION
## Summary
- support optional `redirectOnAuthError` flag in `apiRequest`
- skip redirect for profile page unauthorized errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e5db2d948323943d42a70cdd9c53