### PR TITLE
Handle missing auth token before API request

### DIFF
--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -19,6 +19,9 @@ export async function apiRequest(endpoint, { redirectOnAuthError = true, ...opti
   try {
     response = await fetchWithAuth(url, options);
   } catch (e) {
+    if (e.message === 'Missing token') {
+      throw new Error('Missing authentication token');
+    }
     throw new Error('Network error');
   }
   if (response.status === 401 || response.status === 403) {

--- a/PetIA/js/token.js
+++ b/PetIA/js/token.js
@@ -28,10 +28,11 @@ export function clearToken() {
 
 export async function fetchWithAuth(input, options = {}) {
   const token = getToken();
-  const headers = new Headers(options.headers || {});
-  if (token) {
-    headers.set('Authorization', `Bearer ${token}`);
+  if (!token) {
+    throw new Error('Missing token');
   }
+  const headers = new Headers(options.headers || {});
+  headers.set('Authorization', `Bearer ${token}`);
   // Consumers can supply `credentials` in options when cookies are needed
   return fetch(input, { ...options, headers });
 }

--- a/__tests__/api.test.js
+++ b/__tests__/api.test.js
@@ -50,23 +50,18 @@ describe('apiRequest', () => {
   test('401 without token redirects', async () => {
     delete window.location;
     window.location = { href: '' };
-    global.fetch.mockResolvedValue({
-      status: 401,
-      ok: false,
-      headers: new Headers({ 'content-type': 'application/json' }),
-      json: async () => ({ message: 'Unauthorized' }),
-    });
-    await expect(apiRequest('/test')).rejects.toThrow('Unauthorized');
-    expect(window.location.href).toBe('index.html');
-    expect(localStorage.getItem('restoreCart')).toBe('1');
+    await expect(apiRequest('/test')).rejects.toThrow('Missing authentication token');
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   test('throws Network error on fetch failure', async () => {
+    setToken(createValidToken());
     global.fetch.mockRejectedValue(new Error('failed'));
     await expect(apiRequest('/test')).rejects.toThrow('Network error');
   });
 
   test('throws on boolean false response', async () => {
+    setToken(createValidToken());
     global.fetch.mockResolvedValue({
       status: 200,
       ok: true,
@@ -77,6 +72,7 @@ describe('apiRequest', () => {
   });
 
   test('throws on non JSON response', async () => {
+    setToken(createValidToken());
     global.fetch.mockResolvedValue({
       status: 200,
       ok: true,

--- a/__tests__/token.test.js
+++ b/__tests__/token.test.js
@@ -32,12 +32,19 @@ describe('fetchWithAuth', () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: true });
   });
 
+  test('throws when token is missing', async () => {
+    await expect(fetchWithAuth('/test')).rejects.toThrow('Missing token');
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   test('does not set credentials by default', async () => {
+    setToken('abc');
     await fetchWithAuth('/test');
     expect(global.fetch.mock.calls[0][1].credentials).toBeUndefined();
   });
 
   test('respects credentials option when provided', async () => {
+    setToken('abc');
     await fetchWithAuth('/test', { credentials: 'include' });
     expect(global.fetch.mock.calls[0][1].credentials).toBe('include');
   });


### PR DESCRIPTION
## Summary
- Throw `Missing token` error when `fetchWithAuth` has no stored token
- Surface `Missing authentication token` in `apiRequest` before sending request
- Update tests for new missing-token behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1e9b8142083238f1d11f11adbde7c