### PR TITLE
Persist auth token and opt-out redirects

### DIFF
--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -1,6 +1,9 @@
 import config from '../config.js';
 import { apiRequest } from './api.js';
 import { addItem } from './cart.js';
+import { ensureAuth } from './token.js';
+
+ensureAuth();
 
 const loadedCategories = new Map();
 let allCategories = [];

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -19,10 +19,12 @@
   <script type="module">
     import config from './config.js';
     import { apiRequest } from './js/api.js';
+    import { ensureAuth } from './js/token.js';
 
-    async function load() {
-      try {
-        const data = await apiRequest(config.endpoints.profile, { redirectOnAuthError: false });
+    if (ensureAuth()) {
+      async function load() {
+        try {
+          const data = await apiRequest(config.endpoints.profile);
         const profile = document.getElementById('profile');
         profile.innerHTML = `
           <p><strong>Usuario:</strong> ${data.username}</p>
@@ -43,9 +45,10 @@
         }
         document.getElementById('profile').textContent = message;
       }
-    }
+      }
 
-    load();
+      load();
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Store auth token in sessionStorage, localStorage, and cookies with helper to verify presence
- Default API requests to avoid redirecting on auth errors while still allowing opt-in
- Validate token on profile and store pages before making API calls

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ed0d29ec8323a9742b6a5337f49d