### PR TITLE
Default to include credentials in fetchWithAuth

### DIFF
--- a/PetIA/js/token.js
+++ b/PetIA/js/token.js
@@ -48,8 +48,8 @@ export async function fetchWithAuth(input, options = {}) {
   }
   const headers = new Headers(options.headers || {});
   headers.set('Authorization', `Bearer ${token}`);
-  // Consumers can supply `credentials` in options when cookies are needed
-  return fetch(input, { ...options, headers });
+  // Include credentials by default but allow consumers to override via `options`
+  return fetch(input, { credentials: 'include', ...options, headers });
 }
 
 export function ensureAuth() {

--- a/__tests__/token.test.js
+++ b/__tests__/token.test.js
@@ -40,12 +40,12 @@ describe('fetchWithAuth', () => {
   test('does not set credentials by default', async () => {
     setToken('abc');
     await fetchWithAuth('/test');
-    expect(global.fetch.mock.calls[0][1].credentials).toBeUndefined();
+    expect(global.fetch.mock.calls[0][1].credentials).toBe('include');
   });
 
-  test('respects credentials option when provided', async () => {
+  test('allows overriding credentials option', async () => {
     setToken('abc');
-    await fetchWithAuth('/test', { credentials: 'include' });
-    expect(global.fetch.mock.calls[0][1].credentials).toBe('include');
+    await fetchWithAuth('/test', { credentials: 'omit' });
+    expect(global.fetch.mock.calls[0][1].credentials).toBe('omit');
   });
 });


### PR DESCRIPTION
## Summary
- Ensure `fetchWithAuth` includes credentials by default while allowing consumers to override via options
- Update tests for new credential behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f1e61b088323a3be34026a364b88