### PR TITLE
Protect cart page with auth

### DIFF
--- a/PetIA/js/cart-page.js
+++ b/PetIA/js/cart-page.js
@@ -1,3 +1,4 @@
+import { ensureAuth } from './token.js';
 import { getCart, updateItem, removeItem } from './cart.js';
 
 async function renderCart() {
@@ -58,6 +59,9 @@ function checkout() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  if (!ensureAuth()) {
+    return;
+  }
   document
     .getElementById('clear-cart')
     .addEventListener('click', clearCart);


### PR DESCRIPTION
## Summary
- import ensureAuth in cart page
- Guard cart rendering behind ensureAuth and skip if not logged in

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1f2b445d883238097d6cbb1b9df78