### PR TITLE
Return WordPress user ID on validate-token

### DIFF
--- a/PetIA-app-bridge/README.md
+++ b/PetIA-app-bridge/README.md
@@ -22,7 +22,7 @@ Las dependencias PHP necesarias ya están incluidas, por lo que no es necesario 
 - `POST /wp-json/petia-app-bridge/v1/register`
 - `POST /wp-json/petia-app-bridge/v1/login`
 - `POST /wp-json/petia-app-bridge/v1/logout`
-- `GET /wp-json/petia-app-bridge/v1/validate-token`
+- `GET /wp-json/petia-app-bridge/v1/validate-token` – devuelve `{ "valid": true, "user_id": <ID> }` si el token es válido
 - `POST /wp-json/petia-app-bridge/v1/password-reset-request`
 - `POST /wp-json/petia-app-bridge/v1/password-reset`
 - `GET /wp-json/petia-app-bridge/v1/profile`

--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -275,7 +275,7 @@ class App_Bridge {
                 return new \WP_Error( 'forbidden', 'User not allowed', [ 'status' => 403 ] );
             }
 
-            return [ 'valid' => true, 'user_id' => $user_id ];
+            return [ 'valid' => true, 'user_id' => (int) $user->ID ];
         } catch ( \Exception $e ) {
             return new \WP_Error( 'invalid_token', $e->getMessage(), [ 'status' => 401 ] );
         }


### PR DESCRIPTION
## Summary
- Include the WordPress user's ID in the validate-token endpoint response
- Document that validate-token returns the user's ID when the token is valid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c1fbe7772c83238fc44a7eb82fb0b7