### PR TITLE
Disable WooCommerce Store API nonce check

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -10,6 +10,7 @@ class App_Bridge {
         add_filter( 'determine_current_user', [ $this, 'determine_current_user' ], 20 );
         add_action( 'rest_api_init', [ $this, 'register_routes' ] );
         add_filter( 'rest_authentication_errors', [ $this, 'authenticate_requests' ] );
+        add_filter( 'woocommerce_store_api_disable_nonce_check', '__return_true' );
 
         if ( is_admin() ) {
             new Admin();


### PR DESCRIPTION
## Summary
- disable Store API nonce verification because JWT authentication sets current user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c23b24cb148323a850c66962235c80