### PR TITLE
feat: support variable products in cart

### DIFF
--- a/PetIA-app-bridge/includes/App_Bridge.php
+++ b/PetIA-app-bridge/includes/App_Bridge.php
@@ -491,13 +491,31 @@ class App_Bridge {
         $products = wc_get_products( $args );
         $data     = [];
         foreach ( $products as $product ) {
-            $image_id  = $product->get_image_id();
-            $data[] = [
+            $image_id = $product->get_image_id();
+            $item     = [
                 'id'    => $product->get_id(),
                 'name'  => $product->get_name(),
                 'price' => $product->get_price(),
                 'image' => $image_id ? wp_get_attachment_url( $image_id ) : '',
+                'type'  => $product->get_type(),
             ];
+            if ( 'variable' === $product->get_type() ) {
+                $attributes = [];
+                foreach ( $product->get_variation_attributes() as $taxonomy => $options ) {
+                    $attributes[ $taxonomy ] = array_values( $options );
+                }
+                $item['attributes'] = $attributes;
+                $item['variations'] = array_map(
+                    function( $variation ) {
+                        return [
+                            'id'         => $variation['variation_id'],
+                            'attributes' => $variation['attributes'],
+                        ];
+                    },
+                    $product->get_available_variations()
+                );
+            }
+            $data[] = $item;
         }
         return $data;
     }

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -28,15 +28,32 @@ function renderProducts(products, panel) {
   products.forEach(p => {
     const li = document.createElement('li');
     li.className = 'product';
+    let attrsHtml = '';
+    if (p.type === 'variable' && p.attributes) {
+      Object.entries(p.attributes).forEach(([attr, options]) => {
+        const opts = options
+          .map(o => `<option value="${o}">${o}</option>`) // simple label
+          .join('');
+        attrsHtml += `<label>${attr}<select data-attr="${attr}">${opts}</select></label>`;
+      });
+    }
     li.innerHTML = `
       <img src="${p.image}" alt="${p.name}" />
       <div class="name">${p.name}</div>
       <div class="price">${p.price}</div>
+      ${attrsHtml}
       <button class="add-cart">Añadir</button>
     `;
     const btn = li.querySelector('.add-cart');
     btn.addEventListener('click', async () => {
-      await addItem(p.id, 1);
+      let variation;
+      if (p.type === 'variable' && p.attributes) {
+        variation = {};
+        li.querySelectorAll('select[data-attr]').forEach(sel => {
+          variation[sel.dataset.attr] = sel.value;
+        });
+      }
+      await addItem(p.id, 1, variation);
       alert('Producto agregado');
     });
     list.appendChild(li);

--- a/__tests__/cart.test.js
+++ b/__tests__/cart.test.js
@@ -32,5 +32,16 @@ describe('cart', () => {
     const url = second.mock.calls[0][0];
     expect(url).toMatch(/cart_key=abc123/);
   });
+
+  test('includes variation in request body', async () => {
+    const mockApi = jest.fn(async () => ({ items: [] }));
+    jest.unstable_mockModule('../PetIA/js/api.js', () => ({ apiRequest: mockApi }));
+    const { addItem } = await import('../PetIA/js/cart.js');
+    sessionStorage.setItem('token', 't');
+    const variation = { attribute_pa_color: 'blue', attribute_pa_size: 'm' };
+    await addItem(10, 1, variation);
+    const body = JSON.parse(mockApi.mock.calls[0][1].body);
+    expect(body.variation).toEqual(variation);
+  });
 });
 


### PR DESCRIPTION
## Summary
- handle product variations in cart and local storage
- render variation attribute selectors and submit chosen options
- expose product type and variation data in product endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c243c64c888323867b88b4f80b4d02