### PR TITLE
Handle variable product variations before adding to cart

### DIFF
--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -46,14 +46,26 @@ function renderProducts(products, panel) {
     `;
     const btn = li.querySelector('.add-cart');
     btn.addEventListener('click', async () => {
-      let variation;
+      let variationSeleccionada;
       if (p.type === 'variable' && p.attributes) {
-        variation = {};
+        variationSeleccionada = {};
         li.querySelectorAll('select[data-attr]').forEach(sel => {
-          variation[sel.dataset.attr] = sel.value;
+          variationSeleccionada[sel.dataset.attr] = sel.value;
         });
+        const variationMatch = p.variations?.find(v => {
+          const attrs = v.attributes || {};
+          return Object.entries(variationSeleccionada).every(
+            ([attr, val]) => attrs[attr] === val
+          );
+        });
+        if (!variationMatch) {
+          alert('Variación no encontrada');
+          return;
+        }
+        await addItem(variationMatch.id, 1, variationSeleccionada);
+      } else {
+        await addItem(p.id, 1);
       }
-      await addItem(p.id, 1, variation);
       alert('Producto agregado');
     });
     list.appendChild(li);


### PR DESCRIPTION
## Summary
- Match selected attributes against available product variations
- Add variable products to cart using the matching variation ID
- Show a warning when the selected variation does not exist

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2475d469c8323b0d552fcde723e2b