### PR TITLE
Convert variation map to array in cart operations

### DIFF
--- a/PetIA/js/cart.js
+++ b/PetIA/js/cart.js
@@ -63,13 +63,19 @@ export async function syncLocalCart() {
   if (!getToken()) return;
   const items = getLocalCart();
   for (const item of items) {
+    const variationPayload = item.variation
+      ? Object.entries(item.variation).map(([attribute, value]) => ({
+          attribute,
+          value,
+        }))
+      : undefined;
     await cartRequest(config.endpoints.cartAddItem, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         id: item.id,
         quantity: item.quantity,
-        ...(item.variation ? { variation: item.variation } : {}),
+        ...(variationPayload ? { variation: variationPayload } : {}),
       }),
     });
   }
@@ -96,13 +102,19 @@ export function addItem(productId, quantity, variation) {
     setLocalCart(cart);
     return Promise.resolve({ items: cart });
   }
+  const variationPayload = variation
+    ? Object.entries(variation).map(([attribute, value]) => ({
+        attribute,
+        value,
+      }))
+    : undefined;
   return cartRequest(config.endpoints.cartAddItem, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       id: productId,
       quantity,
-      ...(variation ? { variation } : {}),
+      ...(variationPayload ? { variation: variationPayload } : {}),
     }),
   });
 }

--- a/__tests__/cart.test.js
+++ b/__tests__/cart.test.js
@@ -41,7 +41,10 @@ describe('cart', () => {
     const variation = { attribute_pa_color: 'blue', attribute_pa_size: 'm' };
     await addItem(10, 1, variation);
     const body = JSON.parse(mockApi.mock.calls[0][1].body);
-    expect(body.variation).toEqual(variation);
+    expect(body.variation).toEqual([
+      { attribute: 'attribute_pa_color', value: 'blue' },
+      { attribute: 'attribute_pa_size', value: 'm' },
+    ]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Send variation data as attribute/value array when syncing or adding cart items
- Adjust cart tests to expect variation payload arrays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c258f8b3288323be21bae36bf114a5