### PR TITLE
feat: add loading overlay for API requests

### DIFF
--- a/PetIA/cart.html
+++ b/PetIA/cart.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/loading.css" />
   <title>PetIA Cart</title>
 </head>
 <body>
@@ -34,7 +35,8 @@
       <button id="checkout-button">Finalizar compra</button>
     </div>
   </div>
-  <script type="module" src="./js/logout.js"></script>
-  <script type="module" src="./js/cart-page.js"></script>
+    <script type="module" src="./js/loading.js"></script>
+    <script type="module" src="./js/logout.js"></script>
+    <script type="module" src="./js/cart-page.js"></script>
 </body>
 </html>

--- a/PetIA/css/loading.css
+++ b/PetIA/css/loading.css
@@ -1,0 +1,27 @@
+#loading-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 9999;
+}
+
+#loading-overlay .spinner {
+  width: 50px;
+  height: 50px;
+  border: 6px solid #fff;
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/loading.css" />
   <title>PetIA Login</title>
 </head>
 <body>
@@ -13,7 +14,8 @@
     <input type="password" id="password" placeholder="Password" />
     <button type="submit">Login</button>
   </form>
-  <script type="module">
+    <script type="module" src="./js/loading.js"></script>
+    <script type="module">
     import config from './config.js';
     import { setToken } from './js/token.js';
     import { syncLocalCart, getCart, getCartKey } from './js/cart.js';

--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -1,5 +1,6 @@
 import config from '../config.js';
 import { getToken, clearToken, fetchWithAuth, isTokenExpired } from './token.js';
+import { showLoading, hideLoading } from './loading.js';
 
 export async function apiRequest(endpoint, { redirectOnAuthError = false, ...options } = {}) {
   const token = getToken();
@@ -24,9 +25,12 @@ export async function apiRequest(endpoint, { redirectOnAuthError = false, ...opt
   }
   let response;
   try {
+    showLoading();
     response = await fetchWithAuth(url, options);
   } catch (e) {
     throw new Error('Network error');
+  } finally {
+    hideLoading();
   }
   if (response.status === 401 || response.status === 403) {
     let errorBody = {};

--- a/PetIA/js/loading.js
+++ b/PetIA/js/loading.js
@@ -1,0 +1,17 @@
+let overlay;
+
+export function showLoading() {
+  if (overlay) return;
+  overlay = document.createElement('div');
+  overlay.id = 'loading-overlay';
+  const spinner = document.createElement('div');
+  spinner.className = 'spinner';
+  overlay.appendChild(spinner);
+  document.body.appendChild(overlay);
+}
+
+export function hideLoading() {
+  if (!overlay) return;
+  overlay.remove();
+  overlay = null;
+}

--- a/PetIA/store.html
+++ b/PetIA/store.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/loading.css" />
   <title>PetIA Store</title>
 </head>
 <body>
@@ -17,7 +18,8 @@
   <h1>Store</h1>
   <div id="category-tabs" class="tabs"></div>
   <div id="category-content"></div>
-  <script type="module" src="./js/logout.js"></script>
-  <script type="module" src="./js/store.js"></script>
+    <script type="module" src="./js/loading.js"></script>
+    <script type="module" src="./js/logout.js"></script>
+    <script type="module" src="./js/store.js"></script>
 </body>
 </html>

--- a/PetIA/user.html
+++ b/PetIA/user.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/loading.css" />
   <title>PetIA Profile</title>
 </head>
 <body>
@@ -15,7 +16,8 @@
   </nav>
   <h1>User Profile</h1>
   <div id="profile"></div>
-  <script type="module" src="./js/logout.js"></script>
+    <script type="module" src="./js/loading.js"></script>
+    <script type="module" src="./js/logout.js"></script>
   <script type="module">
     import config from './config.js';
     import { apiRequest } from './js/api.js';


### PR DESCRIPTION
## Summary
- add reusable loading overlay module and styles
- show loading overlay during api calls
- include loading assets in pages using api requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c25f320c708323bdca117db128f295