### PR TITLE
feat: add loading spinner on async buttons

### DIFF
--- a/PetIA/js/cart-page.js
+++ b/PetIA/js/cart-page.js
@@ -29,13 +29,28 @@ async function renderCart() {
       `;
       const qtyInput = tr.querySelector('input');
       qtyInput.addEventListener('change', async () => {
-        const qty = parseInt(qtyInput.value, 10);
-        await updateItem(item.key, qty);
-        renderCart();
+        qtyInput.disabled = true;
+        qtyInput.classList.add('loading');
+        try {
+          const qty = parseInt(qtyInput.value, 10);
+          await updateItem(item.key, qty);
+          renderCart();
+        } finally {
+          qtyInput.disabled = false;
+          qtyInput.classList.remove('loading');
+        }
       });
-      tr.querySelector('.remove').addEventListener('click', async () => {
-        await removeItem(item.key);
-        renderCart();
+      const removeBtn = tr.querySelector('.remove');
+      removeBtn.addEventListener('click', async () => {
+        removeBtn.disabled = true;
+        removeBtn.classList.add('loading');
+        try {
+          await removeItem(item.key);
+          renderCart();
+        } finally {
+          removeBtn.disabled = false;
+          removeBtn.classList.remove('loading');
+        }
       });
       tbody.appendChild(tr);
     });
@@ -44,13 +59,19 @@ async function renderCart() {
   }
 }
 
-async function clearCart() {
+async function clearCart(e) {
+  const btn = e?.currentTarget;
+  btn.disabled = true;
+  btn.classList.add('loading');
   try {
     const cart = await getCart();
     await Promise.all((cart.items || []).map(i => removeItem(i.key)));
     renderCart();
   } catch (error) {
     console.error('Error al vaciar el carrito:', error);
+  } finally {
+    btn.disabled = false;
+    btn.classList.remove('loading');
   }
 }
 

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -46,27 +46,34 @@ function renderProducts(products, panel) {
     `;
     const btn = li.querySelector('.add-cart');
     btn.addEventListener('click', async () => {
-      let variationSeleccionada;
-      if (p.type === 'variable' && p.attributes) {
-        variationSeleccionada = {};
-        li.querySelectorAll('select[data-attr]').forEach(sel => {
-          variationSeleccionada[sel.dataset.attr] = sel.value;
-        });
-        const variationMatch = p.variations?.find(v => {
-          const attrs = v.attributes || {};
-          return Object.entries(variationSeleccionada).every(
-            ([attr, val]) => attrs[attr] === val
-          );
-        });
-        if (!variationMatch) {
-          alert('Variación no encontrada');
-          return;
+      btn.disabled = true;
+      btn.classList.add('loading');
+      try {
+        let variationSeleccionada;
+        if (p.type === 'variable' && p.attributes) {
+          variationSeleccionada = {};
+          li.querySelectorAll('select[data-attr]').forEach(sel => {
+            variationSeleccionada[sel.dataset.attr] = sel.value;
+          });
+          const variationMatch = p.variations?.find(v => {
+            const attrs = v.attributes || {};
+            return Object.entries(variationSeleccionada).every(
+              ([attr, val]) => attrs[attr] === val
+            );
+          });
+          if (!variationMatch) {
+            alert('Variación no encontrada');
+            return;
+          }
+          await addItem(variationMatch.id, 1, variationSeleccionada);
+        } else {
+          await addItem(p.id, 1);
         }
-        await addItem(variationMatch.id, 1, variationSeleccionada);
-      } else {
-        await addItem(p.id, 1);
+        alert('Producto agregado');
+      } finally {
+        btn.disabled = false;
+        btn.classList.remove('loading');
       }
-      alert('Producto agregado');
     });
     list.appendChild(li);
   });

--- a/README.md
+++ b/README.md
@@ -13,6 +13,20 @@ Las dependencias PHP vienen incluidas, por lo que no es necesario ejecutar `comp
 1. Sirve la carpeta `PetIA/` en cualquier servidor estático.
 2. Ajusta `API_BASE_URL` si la API está en otra URL (ver `PetIA/config.js`).
 
+## Interacciones con botones
+Al realizar operaciones que invoquen `apiRequest`, deshabilita el botón involucrado y agrega la clase `loading` hasta que la petición finalice. Esto evita múltiples envíos y permite mostrar un spinner interno.
+
+```js
+button.disabled = true;
+button.classList.add('loading');
+try {
+  await apiRequest('/endpoint');
+} finally {
+  button.disabled = false;
+  button.classList.remove('loading');
+}
+```
+
 ## Pruebas
 Instala dependencias y ejecuta las pruebas:
 ```bash


### PR DESCRIPTION
## Summary
- disable action buttons and show spinner while API calls run
- re-enable buttons after requests complete
- document reusable button-loading pattern

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c26048a89c83239db129aa1f39bc73