### PR TITLE
Add toast notifications for API requests

### DIFF
--- a/PetIA/css/notifications.css
+++ b/PetIA/css/notifications.css
@@ -1,0 +1,31 @@
+#toast-container {
+  position: fixed;
+  top: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.toast {
+  min-width: 200px;
+  margin-bottom: 10px;
+  padding: 10px 15px;
+  border-radius: 4px;
+  color: #fff;
+  background-color: #333;
+  opacity: 0;
+  transform: translateY(-20px);
+  transition: opacity 0.3s, transform 0.3s;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.toast.success {
+  background-color: #2ecc71;
+}
+
+.toast.error {
+  background-color: #e74c3c;
+}

--- a/PetIA/js/api.js
+++ b/PetIA/js/api.js
@@ -1,76 +1,87 @@
 import config from '../config.js';
 import { getToken, clearToken, fetchWithAuth, isTokenExpired } from './token.js';
 import { showLoading, hideLoading } from './loading.js';
+import { showToast } from './notifications.js';
 
-export async function apiRequest(endpoint, { redirectOnAuthError = false, ...options } = {}) {
-  const token = getToken();
-  if (!token) {
-    if (redirectOnAuthError) {
-      window.location.href = 'index.html';
-    }
-    throw new Error('Missing authentication token');
-  }
-  if (isTokenExpired(token)) {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('restoreCart', '1');
-    }
-    if (redirectOnAuthError) {
-      window.location.href = 'index.html';
-    }
-    throw new Error('Token expired');
-  }
-  let url = endpoint;
-  if (!/^https?:/i.test(endpoint)) {
-    url = config.apiBaseUrl.replace(/\/$/, '') + endpoint;
-  }
-  let response;
+export async function apiRequest(
+  endpoint,
+  { redirectOnAuthError = false, ...options } = {}
+) {
   try {
-    showLoading();
-    response = await fetchWithAuth(url, options);
-  } catch (e) {
-    throw new Error('Network error');
-  } finally {
-    hideLoading();
-  }
-  if (response.status === 401 || response.status === 403) {
-    let errorBody = {};
-    try {
-      errorBody = await response.json();
-    } catch (e) {
-      // ignore JSON parse errors
-    }
-    const message = errorBody.message || errorBody.error || '';
-    const code = errorBody.code || '';
-    const tokenInvalid =
-      code === 'TOKEN_EXPIRED' ||
-      code === 'TOKEN_INVALID' ||
-      /token (?:expired|invalid)/i.test(message);
-    if (tokenInvalid) {
-      if (typeof localStorage !== 'undefined') {
-        localStorage.setItem('restoreCart', '1');
-      }
-      clearToken();
+    const token = getToken();
+    if (!token) {
       if (redirectOnAuthError) {
         window.location.href = 'index.html';
       }
-      throw new Error('Unauthorized');
+      throw new Error('Missing authentication token');
     }
-    throw new Error('Authorization failed. Please retry.');
+    if (isTokenExpired(token)) {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('restoreCart', '1');
+      }
+      if (redirectOnAuthError) {
+        window.location.href = 'index.html';
+      }
+      throw new Error('Token expired');
+    }
+    let url = endpoint;
+    if (!/^https?:/i.test(endpoint)) {
+      url = config.apiBaseUrl.replace(/\/$/, '') + endpoint;
+    }
+    let response;
+    try {
+      showLoading();
+      response = await fetchWithAuth(url, options);
+    } catch (e) {
+      throw new Error('Network error');
+    } finally {
+      hideLoading();
+    }
+    if (response.status === 401 || response.status === 403) {
+      let errorBody = {};
+      try {
+        errorBody = await response.json();
+      } catch (e) {
+        // ignore JSON parse errors
+      }
+      const message = errorBody.message || errorBody.error || '';
+      const code = errorBody.code || '';
+      const tokenInvalid =
+        code === 'TOKEN_EXPIRED' ||
+        code === 'TOKEN_INVALID' ||
+        /token (?:expired|invalid)/i.test(message);
+      if (tokenInvalid) {
+        if (typeof localStorage !== 'undefined') {
+          localStorage.setItem('restoreCart', '1');
+        }
+        clearToken();
+        if (redirectOnAuthError) {
+          window.location.href = 'index.html';
+        }
+        throw new Error('Unauthorized');
+      }
+      throw new Error('Authorization failed. Please retry.');
+    }
+    if (!response.ok) {
+      const message =
+        response.status >= 500 ? 'Server error' : 'Unexpected response';
+      throw new Error(message);
+    }
+    const contentType = response.headers.get('content-type') || '';
+    if (!contentType.includes('application/json')) {
+      throw new Error('Invalid JSON response');
+    }
+    const data = await response.json();
+    if (data === false) {
+      throw new Error('Respuesta no válida del servidor');
+    }
+    if (data && data.error) {
+      throw new Error(data.error);
+    }
+    showToast('Operación exitosa', 'success');
+    return data;
+  } catch (error) {
+    showToast('Error al procesar', 'error');
+    throw error;
   }
-  if (!response.ok) {
-    const message = response.status >= 500 ? 'Server error' : 'Unexpected response';
-    throw new Error(message);
-  }
-  const contentType = response.headers.get('content-type') || '';
-  if (!contentType.includes('application/json')) {
-    throw new Error('Invalid JSON response');
-  }
-  const data = await response.json();
-  if (data === false) {
-    throw new Error('Respuesta no válida del servidor');
-  }
-  if (data && data.error) {
-    throw new Error(data.error);
-  }
-  return data;
 }

--- a/PetIA/js/notifications.js
+++ b/PetIA/js/notifications.js
@@ -1,0 +1,25 @@
+export function showToast(message, type = 'success') {
+  if (typeof document === 'undefined') return;
+  let container = document.getElementById('toast-container');
+  if (!container) {
+    container = document.createElement('div');
+    container.id = 'toast-container';
+    document.body.appendChild(container);
+  }
+  if (!document.getElementById('toast-styles')) {
+    const link = document.createElement('link');
+    link.id = 'toast-styles';
+    link.rel = 'stylesheet';
+    link.href = 'css/notifications.css';
+    document.head.appendChild(link);
+  }
+  const toast = document.createElement('div');
+  toast.className = `toast ${type}`;
+  toast.textContent = message;
+  container.appendChild(toast);
+  setTimeout(() => toast.classList.add('show'), 10);
+  setTimeout(() => {
+    toast.classList.remove('show');
+    toast.addEventListener('transitionend', () => toast.remove());
+  }, 3000);
+}


### PR DESCRIPTION
## Summary
- add notification component and styling
- show success/error toasts for apiRequest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c261fbe4688323b4250b41f775e7c8