### PR TITLE
Use toast for password recovery notification

### DIFF
--- a/PetIA/recover.html
+++ b/PetIA/recover.html
@@ -14,6 +14,7 @@
   </form>
   <script type="module">
     import config from './config.js';
+    import { showToast } from './js/notifications.js';
     const form = document.getElementById('recoverForm');
     form.addEventListener('submit', async e => {
       e.preventDefault();
@@ -22,7 +23,7 @@
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email: email.value }),
       });
-      alert('Check your email');
+      showToast('Check your email', 'success');
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- import toast utility in the password recovery page
- display success toast after password reset request instead of alert

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c265fb635083239b204054da0bd865