### PR TITLE
feat: improve product grid layout

### DIFF
--- a/PetIA/README.md
+++ b/PetIA/README.md
@@ -10,6 +10,9 @@ Aplicación web estática que consume los endpoints del plugin PetIA App Bridge.
 2. Ajusta `API_BASE_URL` si tu WordPress corre en otra URL.
 3. Abre `index.html` para iniciar sesión.
 
+## Personalización
+- El tamaño de las miniaturas de productos se controla con la variable CSS `--product-img-size`. Cambia su valor en `css/styles.css` o mediante un estilo inline, por ejemplo: `<ul class="product-list" style="--product-img-size: 100px">`.
+
 ## Categorías de productos
 
 El endpoint `/wp-json/petia-app-bridge/v1/product-categories` ahora devuelve un arreglo de objetos con la forma:

--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -97,22 +97,24 @@ ul {
   display: block;
 }
 
-.tab-panel ul {
-  display: flex;
-  flex-wrap: wrap;
+.product-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
   gap: 1rem;
 }
 
-.tab-panel li.product {
+.product-list li.product {
   border: 1px solid #ccc;
   padding: 0.5rem;
   width: 150px;
   text-align: center;
 }
 
-.tab-panel li.product img {
-  max-width: 100%;
-  height: auto;
+/* Change --product-img-size here or via inline style to adjust thumbnail size */
+.product-list li.product img {
+  width: var(--product-img-size, 80px);
+  height: var(--product-img-size, 80px);
+  object-fit: cover;
 }
 
 /* Responsive adjustments */

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -27,6 +27,7 @@ async function loadCategoryProducts(categoryId) {
 function renderProducts(products, panel) {
   panel.innerHTML = '';
   const list = document.createElement('ul');
+  list.className = 'product-list';
   panel.appendChild(list);
   products.forEach(p => {
     const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- display store products in a responsive grid via new `.product-list`
- allow changing product thumbnail size with `--product-img-size`
- document how to customize thumbnail size in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c272c13d608323aa5f5c0fa6cf05db