### PR TITLE
Make product images responsive and remove obsolete CSS variable

### DIFF
--- a/PetIA/README.md
+++ b/PetIA/README.md
@@ -11,7 +11,7 @@ Aplicación web estática que consume los endpoints del plugin PetIA App Bridge.
 3. Abre `index.html` para iniciar sesión.
 
 ## Personalización
-- El tamaño de las miniaturas de productos se controla con la variable CSS `--product-img-size`. Cambia su valor en `css/styles.css` o mediante un estilo inline, por ejemplo: `<ul class="product-list" style="--product-img-size: 100px">`.
+- Las imágenes de producto se adaptan automáticamente al ancho de su contenedor conservando la proporción.
 
 ## Categorías de productos
 

--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -53,10 +53,6 @@ ul {
   padding: 0;
 }
 
-:root {
-  --product-img-size: 240px;
-}
-
 .addresses {
   display: flex;
   gap: 1rem;
@@ -113,11 +109,12 @@ ul {
   text-align: center;
 }
 
-/* Change --product-img-size in :root or via inline style to adjust thumbnail size */
+/* Product images scale with container while preserving aspect ratio */
 .product-list li.product img {
-  width: var(--product-img-size, 240px);
-  height: var(--product-img-size, 240px);
-  object-fit: cover;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  object-fit: contain;
 }
 
 /* Responsive adjustments */


### PR DESCRIPTION
## Summary
- Make product images scale with container using `width: 100%`, `height: auto`, and `object-fit: contain`
- Remove unused `--product-img-size` custom property and update documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c27c87d00c832381851d92b71b7251