### PR TITLE
Expose numeric and formatted product prices

### DIFF
--- a/PetIA-app-bridge/includes/Controllers/CatalogController.php
+++ b/PetIA-app-bridge/includes/Controllers/CatalogController.php
@@ -68,11 +68,12 @@ class CatalogController {
         foreach ( $products as $product ) {
             $image_id = $product->get_image_id();
             $item     = [
-                'id'    => $product->get_id(),
-                'name'  => $product->get_name(),
-                'price' => $product->get_price(),
-                'image' => $image_id ? wp_get_attachment_url( $image_id ) : '',
-                'type'  => $product->get_type(),
+                'id'             => $product->get_id(),
+                'name'           => $product->get_name(),
+                'price'          => (float) $product->get_price(),
+                'formatted_price' => function_exists( 'wc_price' ) ? wc_price( $product->get_price() ) : null,
+                'image'          => $image_id ? wp_get_attachment_url( $image_id ) : '',
+                'type'           => $product->get_type(),
             ];
             if ( 'variable' === $product->get_type() ) {
                 $attributes = [];

--- a/PetIA/js/cart-page.js
+++ b/PetIA/js/cart-page.js
@@ -20,9 +20,10 @@ async function renderCart() {
     empty.style.display = 'none';
     cart.items.forEach(item => {
       const tr = document.createElement('tr');
+      const price = item.formatted_price ?? item.price ?? item.prices?.price ?? '';
       tr.innerHTML = `
         <td>${item.name}</td>
-        <td>${item.prices?.price ?? ''}</td>
+        <td>${price}</td>
         <td><input type="number" min="1" value="${item.quantity}" /></td>
         <td>${item.totals?.line_total ?? ''}</td>
         <td><button class="remove">Eliminar</button></td>

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -44,7 +44,7 @@ function renderProducts(products, panel) {
     li.innerHTML = `
       <img src="${p.image}" alt="${p.name}" />
       <div class="name">${p.name}</div>
-      <div class="price">${p.price}</div>
+      <div class="price">${p.formatted_price ?? p.price}</div>
       ${attrsHtml}
       <button class="add-cart">Añadir</button>
     `;

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Las dependencias PHP vienen incluidas, por lo que no es necesario ejecutar `comp
 1. Sirve la carpeta `PetIA/` en cualquier servidor estático.
 2. Ajusta `API_BASE_URL` si la API está en otra URL (ver `PetIA/config.js`).
 
+## Precios
+Los endpoints que devuelven productos proporcionan ahora dos campos de precio:
+
+- `price`: valor numérico del producto.
+- `formatted_price`: versión formateada (por ejemplo, con moneda) que puede usarse como respaldo opcional.
+
+El frontend utiliza `price` como número y, si está disponible, muestra `formatted_price`.
+
 ## Interacciones con botones
 Al realizar operaciones que invoquen `apiRequest`, deshabilita el botón involucrado y agrega la clase `loading` hasta que la petición finalice. Esto evita múltiples envíos y permite mostrar un spinner interno.
 


### PR DESCRIPTION
## Summary
- Return numeric `price` and human-readable `formatted_price` for products
- Adjust frontend to consume numeric price with optional formatted fallback
- Document price fields in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c2829921d883238017ca6771ef9098