### PR TITLE
Limit product card size and scale images

### DIFF
--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -101,7 +101,7 @@ ul {
 
 .product-list {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(0, 300px));
   gap: 1rem;
   justify-content: center;
   justify-items: center;
@@ -111,6 +111,11 @@ ul {
   border: 1px solid #ccc;
   padding: 0.5rem;
   text-align: center;
+  max-width: 300px;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 
 /* Product images scale with container while preserving aspect ratio */
@@ -118,6 +123,7 @@ ul {
   width: 100%;
   height: auto;
   max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
 }
 


### PR DESCRIPTION
## Summary
- Restrict product grid to columns no wider than 300 px while keeping items centered
- Constrain product cards to 300 × 400 px with a flex column layout and overflow handling
- Ensure product images scale within card bounds without distortion

## Testing
- `npm test`
- ⚠️ `npx -y -p puppeteer node <<'NODE' ... NODE` *(puppeteer not installed: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_68c28fbf0c408323b54316a99f6137e0