### PR TITLE
Add password reset page and login link

### DIFF
--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -14,7 +14,8 @@
     <input type="password" id="password" placeholder="Password" />
     <button type="submit">Login</button>
   </form>
-    <script type="module">
+  <a href="password-reset.html" id="forgotPasswordLink">Forgot your password?</a>
+  <script type="module">
     import config from './config.js';
     import { setToken } from './js/token.js';
     import { syncLocalCart, getCart, getCartKey } from './js/cart.js';

--- a/PetIA/password-reset.html
+++ b/PetIA/password-reset.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="css/styles.css" />
+  <link rel="stylesheet" href="css/loading.css" />
+  <title>Password Reset</title>
+</head>
+<body>
+  <h1>Password Reset</h1>
+  <form id="requestForm">
+    <input type="email" id="email" placeholder="Email" />
+    <button type="submit">Enviar</button>
+  </form>
+  <form id="resetForm" style="display: none;">
+    <input type="password" id="newPassword" placeholder="New Password" />
+    <button type="submit">Enviar</button>
+  </form>
+  <p id="message"></p>
+  <script type="module">
+    import config from './config.js';
+    import { showLoading, hideLoading } from './js/loading.js';
+
+    const params = new URLSearchParams(location.search);
+    const login = params.get('login');
+    const key = params.get('key');
+
+    const requestForm = document.getElementById('requestForm');
+    const resetForm = document.getElementById('resetForm');
+    const messageEl = document.getElementById('message');
+
+    function showMessage(text, isError = false) {
+      messageEl.textContent = text;
+      messageEl.style.color = isError ? 'red' : 'green';
+    }
+
+    if (login && key) {
+      requestForm.style.display = 'none';
+      resetForm.style.display = 'block';
+      resetForm.addEventListener('submit', async e => {
+        e.preventDefault();
+        showLoading();
+        try {
+          const res = await fetch(
+            config.apiBaseUrl + config.endpoints.passwordReset,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ login, key, password: newPassword.value }),
+            }
+          );
+          if (res.ok) {
+            showMessage('Password updated successfully');
+          } else {
+            const data = await res.json().catch(() => ({}));
+            showMessage(data.message || 'Error updating password', true);
+          }
+        } catch (err) {
+          showMessage(err.message || 'Network error', true);
+        } finally {
+          hideLoading();
+        }
+      });
+    } else {
+      requestForm.addEventListener('submit', async e => {
+        e.preventDefault();
+        showLoading();
+        try {
+          const res = await fetch(
+            config.apiBaseUrl + config.endpoints.passwordResetRequest,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ email: email.value }),
+            }
+          );
+          if (res.ok) {
+            showMessage('Check your email');
+          } else {
+            const data = await res.json().catch(() => ({}));
+            showMessage(data.message || 'Error sending email', true);
+          }
+        } catch (err) {
+          showMessage(err.message || 'Network error', true);
+        } finally {
+          hideLoading();
+        }
+      });
+    }
+  </script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- add Forgot Password link on login page
- create password reset page with email submission and reset flows

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c29353eee48323850f82498f164445