### PR TITLE
Use label/value pairs for store attribute options

### DIFF
--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -43,11 +43,11 @@ function renderProducts(products, panel) {
     li.className = 'product';
     let attrsHtml = '';
     if (p.type === 'variable' && p.attributes) {
-      Object.entries(p.attributes).forEach(([attr, options]) => {
-        const opts = options
-          .map(o => `<option value="${o}">${o}</option>`) // simple label
+      p.attributes.forEach(a => {
+        const opts = (a.options || [])
+          .map(o => `<option value="${o.value}">${o.label}</option>`)
           .join('');
-        attrsHtml += `<label>${attr}<select data-attr="${attr}">${opts}</select></label>`;
+        attrsHtml += `<label>${a.label}<select data-attr="${a.slug}">${opts}</select></label>`;
       });
     }
     const minRange = p.price_range?.min ?? p.min_price;


### PR DESCRIPTION
## Summary
- Render variable attributes using API-provided labels and option value/label pairs
- Keep variation matching based on selected option slug

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c791be06c083238692ffa27ff7a3c6