### PR TITLE
Expose readable variation attributes

### DIFF
--- a/PetIA-app-bridge/includes/Controllers/CatalogController.php
+++ b/PetIA-app-bridge/includes/Controllers/CatalogController.php
@@ -87,13 +87,13 @@ class CatalogController {
                     $attribute_label   = wc_attribute_label( $taxonomy );
                     $attribute_options = [];
                     foreach ( array_values( $options ) as $option ) {
-                        $term              = get_term_by( 'slug', $option, $taxonomy );
+                        $term = get_term_by( 'slug', $option, $taxonomy );
                         $attribute_options[] = [
                             'value' => $option,
                             'label' => $term ? $term->name : $option,
                         ];
                     }
-                    $attributes[ $this->normalize_attribute_key( $taxonomy ) ] = [
+                    $attributes[] = [
                         'label'   => $attribute_label,
                         'options' => $attribute_options,
                     ];


### PR DESCRIPTION
## Summary
- Include attribute label and option names for product variations
- Preserve slug-based attributes in variations for internal logic

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c79ba039c48323abfde4c6e8077a8c