### PR TITLE
Include category images in REST response

### DIFF
--- a/PetIA-app-bridge/includes/Controllers/CatalogController.php
+++ b/PetIA-app-bridge/includes/Controllers/CatalogController.php
@@ -33,12 +33,17 @@ class CatalogController {
             ]
         );
         $data  = array_map(
-            fn( $t ) => [
-                'id'     => $t->term_id,
-                'name'   => $t->name,
-                'parent' => $t->parent,
-                'count'  => (int) $t->count,
-            ],
+            function( $t ) {
+                $thumb_id  = get_term_meta( $t->term_id, 'thumbnail_id', true );
+                $image_url = $thumb_id ? wp_get_attachment_url( $thumb_id ) : '';
+                return [
+                    'id'     => $t->term_id,
+                    'name'   => $t->name,
+                    'parent' => $t->parent,
+                    'count'  => (int) $t->count,
+                    'image'  => $image_url,
+                ];
+            },
             $terms
         );
         return $data;


### PR DESCRIPTION
## Summary
- add category image URLs to catalog endpoint

## Testing
- `php -l PetIA-app-bridge/includes/Controllers/CatalogController.php`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c79f804c348323ac318533fd43f74a