### PR TITLE
feat: add breadcrumbs navigation

### DIFF
--- a/PetIA/css/styles.css
+++ b/PetIA/css/styles.css
@@ -80,6 +80,21 @@ ul {
   margin-bottom: 1rem;
 }
 
+#breadcrumbs {
+  margin-bottom: 1rem;
+  font-size: 0.9rem;
+}
+
+#breadcrumbs span {
+  cursor: pointer;
+  color: #007bff;
+}
+
+#breadcrumbs span:not(:last-child)::after {
+  content: ' > ';
+  color: #333;
+}
+
 .tab {
   cursor: pointer;
   padding: 0.5rem 1rem;

--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -120,6 +120,25 @@ function renderCategoryLevel(parentId) {
   const content = document.getElementById('category-content');
   content.innerHTML = '';
 
+  const breadcrumbsEl = document.getElementById('breadcrumbs');
+  breadcrumbsEl.innerHTML = '';
+
+  const trail = [...navigationStack, parentId];
+  trail.forEach((id, idx) => {
+    const span = document.createElement('span');
+    const cat = allCategories.find(c => c.id === id);
+    span.textContent = cat ? cat.name : 'Inicio';
+
+    if (idx < trail.length - 1) {
+      span.addEventListener('click', () => {
+        navigationStack.splice(idx);
+        renderCategoryLevel(id);
+      });
+    }
+
+    breadcrumbsEl.appendChild(span);
+  });
+
   if (navigationStack.length > 0) {
     const back = document.createElement('button');
     back.textContent = 'Atrás';

--- a/PetIA/store.html
+++ b/PetIA/store.html
@@ -16,7 +16,7 @@
     <a href="#" id="logout-link">Logout</a>
   </nav>
   <h1>Store</h1>
-  <div id="category-tabs" class="tabs"></div>
+  <nav id="breadcrumbs"></nav>
   <div id="category-content"></div>
     <script type="module" src="./js/loading.js"></script>
     <script type="module" src="./js/logout.js"></script>


### PR DESCRIPTION
## Summary
- replace category tabs with breadcrumb container
- render breadcrumb trail based on category navigation
- add styles for breadcrumbs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7a2c1bfa48323b9b4c24ea7a0a8ef