### PR TITLE
Remove back button from category navigation

### DIFF
--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -139,15 +139,7 @@ function renderCategoryLevel(parentId) {
     breadcrumbsEl.appendChild(span);
   });
 
-  if (navigationStack.length > 0) {
-    const back = document.createElement('button');
-    back.textContent = 'Atrás';
-    back.addEventListener('click', () => {
-      const prev = navigationStack.pop();
-      renderCategoryLevel(prev ?? null);
-    });
-    content.appendChild(back);
-  }
+  // Removed back button; navigation relies solely on breadcrumbs.
 
   const cats = allCategories
     .filter(c => (parentId === null ? !c.parent : c.parent === parentId))


### PR DESCRIPTION
## Summary
- eliminate explicit "Atrás" button in store categories
- rely on breadcrumbs for navigation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7a5d4d14083239b471347c92df0b9