### PR TITLE
Actualizar endpoints de checkout y proteger página

### DIFF
--- a/PetIA/checkout.html
+++ b/PetIA/checkout.html
@@ -3,12 +3,16 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <link rel="stylesheet" href="css/styles.css" />
-  <link rel="stylesheet" href="css/loading.css" />
-  <title>PetIA Checkout</title>
-</head>
-<body>
-  <nav>
+    <link rel="stylesheet" href="css/styles.css" />
+    <link rel="stylesheet" href="css/loading.css" />
+    <title>PetIA Checkout</title>
+    <script type="module">
+      import { ensureAuth } from './js/token.js';
+      ensureAuth();
+    </script>
+  </head>
+  <body>
+    <nav>
     <a href="chat.html">Chat</a>
     <a href="store.html">Store</a>
     <a href="cart.html">Cart</a>

--- a/PetIA/config.js
+++ b/PetIA/config.js
@@ -19,7 +19,7 @@ export default {
     cartAddItem: '/wp-json/petia-app-bridge/v1/wc-store/cart/add-item',
     cartUpdateItem: '/wp-json/petia-app-bridge/v1/wc-store/cart/update-item',
     cartRemoveItem: '/wp-json/petia-app-bridge/v1/wc-store/cart/remove-item',
-    paymentMethods: '/wp-json/petia-app-bridge/v1/wc-store/checkout/payment-methods',
-    checkout: '/wp-json/petia-app-bridge/v1/wc-store/checkout',
+    paymentMethods: '/wp-json/petia-app-bridge/v1/payment-methods',
+    checkout: '/wp-json/petia-app-bridge/v1/checkout',
   },
 };

--- a/PetIA/js/cart-page.js
+++ b/PetIA/js/cart-page.js
@@ -76,9 +76,9 @@ async function clearCart(e) {
   }
 }
 
-function checkout() {
-  window.location.href = '/checkout';
-}
+  function checkout() {
+    window.location.href = 'checkout.html';
+  }
 
 document.addEventListener('DOMContentLoaded', () => {
   if (!ensureAuth()) {


### PR DESCRIPTION
## Summary
- Actualizar endpoints de checkout y métodos de pago a las rutas de app-bridge.
- Redirigir al recurso interno `checkout.html` desde la página del carrito.
- Proteger `checkout.html` verificando la autenticación del usuario.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7ab717ce08323a093fcbbd06740a3