### PR TITLE
Handle variable product attributes as arrays

### DIFF
--- a/PetIA/js/store.js
+++ b/PetIA/js/store.js
@@ -43,11 +43,11 @@ function renderProducts(products, panel) {
     li.className = 'product';
     let attrsHtml = '';
     if (p.type === 'variable' && p.attributes) {
-      Object.entries(p.attributes).forEach(([slug, a]) => {
+      (p.attributes || []).forEach(a => {
         const opts = (a.options || [])
           .map(o => `<option value="${o.value}">${o.label}</option>`)
           .join('');
-        attrsHtml += `<label>${a.label}<select data-attr="${slug}">${opts}</select></label>`;
+        attrsHtml += `<label>${a.label}<select data-attr="${a.slug}">${opts}</select></label>`;
       });
     }
     const minRange = p.price_range?.min ?? p.min_price;


### PR DESCRIPTION
## Summary
- Build attribute selectors by iterating over product attribute arrays
- Keep selected variation options keyed by attribute slug for matching variations

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c7b6fd54948323862146736641038b