### PR TITLE
Add register endpoint to PetIA config

### DIFF
--- a/PetIA/config.js
+++ b/PetIA/config.js
@@ -7,6 +7,7 @@ export default {
   apiBaseUrl,
   endpoints: {
     login: '/wp-json/petia-app-bridge/v1/login',
+    register: '/wp-json/petia-app-bridge/v1/register',
     logout: '/wp-json/petia-app-bridge/v1/logout',
     validateToken: '/wp-json/petia-app-bridge/v1/validate-token',
     passwordResetRequest: '/wp-json/petia-app-bridge/v1/password-reset-request',


### PR DESCRIPTION
## Summary
- add the register endpoint URL to the PetIA API configuration

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c736b7188323ab359d86048806fe