### PR TITLE
Add registration page and link from login

### DIFF
--- a/PetIA/index.html
+++ b/PetIA/index.html
@@ -15,6 +15,7 @@
     <button type="submit">Login</button>
   </form>
   <a href="password-reset.html" id="forgotPasswordLink">Forgot your password?</a>
+  <a href="register.html" id="registerLink">Create an account</a>
   <script type="module">
     import config from './config.js';
     import { setToken } from './js/token.js';

--- a/PetIA/register.html
+++ b/PetIA/register.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="css/styles.css" />
+  <title>PetIA Registro</title>
+</head>
+<body>
+  <main>
+    <h1>Crear cuenta</h1>
+    <form id="registerForm">
+      <label for="username">Nombre de usuario</label>
+      <input
+        type="text"
+        id="username"
+        name="username"
+        placeholder="Nombre de usuario"
+        required
+      />
+
+      <label for="firstName">Nombre</label>
+      <input
+        type="text"
+        id="firstName"
+        name="first_name"
+        placeholder="Nombre (opcional)"
+      />
+
+      <label for="lastName">Apellidos</label>
+      <input
+        type="text"
+        id="lastName"
+        name="last_name"
+        placeholder="Apellidos (opcional)"
+      />
+
+      <label for="email">Correo electrónico</label>
+      <input
+        type="email"
+        id="email"
+        name="email"
+        placeholder="Correo electrónico"
+        required
+      />
+
+      <label for="password">Contraseña</label>
+      <input
+        type="password"
+        id="password"
+        name="password"
+        placeholder="Contraseña"
+        required
+      />
+
+      <label for="confirmPassword">Confirmar contraseña</label>
+      <input
+        type="password"
+        id="confirmPassword"
+        name="confirm_password"
+        placeholder="Confirmar contraseña"
+        required
+      />
+
+      <button type="submit">Registrarse</button>
+    </form>
+    <p>¿Ya tienes cuenta? <a href="index.html">Inicia sesión</a></p>
+  </main>
+  <script type="module" src="js/register.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a registration page with username, email, password, confirm password, and optional name fields
- include styling and script references required for the registration page
- link the login page to the new registration page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9c93442f08323876afac3a898596b