### PR TITLE
Follow-up: Guard WP_Error from token generation in registration handler

### DIFF
--- a/PetIA-app-bridge/includes/Controllers/UserController.php
+++ b/PetIA-app-bridge/includes/Controllers/UserController.php
@@ -101,7 +101,10 @@ class UserController {
 
         $token = null;
         try {
-            $token = $this->token_manager->generate_token( $user_id );
+            $generated_token = $this->token_manager->generate_token( $user_id );
+            if ( ! is_wp_error( $generated_token ) ) {
+                $token = $generated_token;
+            }
         } catch ( \Throwable $e ) {
             // If token generation fails, still return a success response without the token.
         }


### PR DESCRIPTION
### Motivation
- Prevent a fatal error when `Token_Manager::generate_token()` returns a `WP_Error` (e.g., JWT unavailable) which was previously concatenated into the `Authorization` header and response.
- Preserve successful registration behavior even when token creation fails by returning a success response without a token.

### Description
- Update `PetIA-app-bridge/includes/Controllers/UserController.php` to store the generator result in `$generated_token` and use `is_wp_error()` to ensure only a non-error value is promoted to `$token` before including it in the response or header.
- Keep the existing flow so the response still returns `success` and `user_id` when token creation fails, and only add `token` and `Authorization` header when a valid token exists.

### Testing
- Ran `php -l PetIA-app-bridge/includes/Controllers/UserController.php` which reported no syntax errors and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb239f3e3883239ee3219c373fb350)